### PR TITLE
Replace separator in index

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -245,7 +245,12 @@ FILES must be a list of filepaths. If nil, all files in
         (let ((id (if zk-index-invisible-ids
                       (propertize (match-string 1 file) 'invisible t)
                     (match-string 1 file)))
-              (title (match-string 2 file)))
+              (title (if (eq zk-file-name-separator " ")
+                         (match-string 2 file)
+                       (replace-regexp-in-string
+                        zk-file-name-separator
+                        " "
+                        (match-string 2 file)))))
           (when id
             (push (concat zk-index-prefix
                           (format-spec format


### PR DESCRIPTION
Dear Grant, 

this PR is a small addition to #5. The modification of `zk-index--format-candidates` ensures proper display of note titles in `*ZK-Index*` if `zk-file-name-separator` is set to something other than a space.

Best regards,
jgru 
