### PR TITLE
Add org-style links

### DIFF
--- a/zk-org.el
+++ b/zk-org.el
@@ -57,7 +57,7 @@
       ;;(print (concat "zk:" zk-curid))
       (org-store-link-props
         :type "zk"
-        :link (concat "zk:" zk-curid)
+        :link (concat "zk:" zk-cur-id)
         :description zk-cur-id))))
 
 (provide 'zk-org)

--- a/zk-org.el
+++ b/zk-org.el
@@ -1,0 +1,55 @@
+;;; zk-org -- Helper functions for working org-style zettelkasten  -*- lexical-binding: t -*-
+; -*-
+
+;; Copyright (C) 2022 jgru
+
+;; Author: jgru <https://github.com/jgru> inspired by Ashlynn Anderson
+;; Created: February 21, 2022
+;; License: GPL-3.0-or-later
+;; Version: 0.1
+;; Homepage: https://github.com/localauthor/zk
+;; Package-Requires: ((emacs "24.4"))
+
+;; This program is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by the Free
+;; Software Foundation, either version 3 of the License, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+;; for more details.
+
+;; You should have received a copy of the GNU General Public License along
+;; with this program. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This set of functions aims to implement support for org-style links within zk
+
+;;; Code:
+(require 'zk)
+
+(with-eval-after-load 'org
+  (org-link-set-parameters "zk"
+			   :follow #'zk-org--follow-link
+			   :store #'zk-org--store-link))
+
+(defun zk-org--follow-link (id)
+  "Follow an zk ID."
+  (let ((file (zk--parse-id 'file-path id)))
+        (if file
+            (find-file file)
+          (user-error "Could not find zk-note with ID %s" id))))
+
+(defun zk-org--store-link ()
+  "Store a link to a zk-note."
+  (when (zk-file-p)
+    (let ((zk-cur-id (zk--current-id)))
+      ;;(print (concat "zk:" zk-curid))
+      (org-store-link-props
+        :type "zk"
+        :link (concat "zk:" zk-curid)
+        :description zk-cur-id))))
+
+(provide 'zk-org)

--- a/zk-org.el
+++ b/zk-org.el
@@ -28,12 +28,20 @@
 ;; This set of functions aims to implement support for org-style links within zk
 
 ;;; Code:
+
 (require 'zk)
 
 (with-eval-after-load 'org
   (org-link-set-parameters "zk"
 			   :follow #'zk-org--follow-link
 			   :store #'zk-org--store-link))
+
+;; Set up org-style link format by setting defcustoms
+(setq zk-link-format "[[zk:%s]]" )
+(setq zk-link-and-title-format "%t [[zk:%i]]")
+(setq zk-completion-at-point-format "[[zk:%i]] %t")
+(setq zk-link-regexp (format (regexp-quote zk-link-format) zk-id-regexp))
+(setq zk-completion-at-point-format  "[[zk:%i]] %t")
 
 (defun zk-org--follow-link (id)
   "Follow an zk ID."


### PR DESCRIPTION
Dear Grant, 

this is an early draft for adding support for org-style links in the form of `zk:ID`. 
By utilizing this, one would benefit from full support of those links within `org` (e.g. for exporting), while avoiding the need to advice `org-open-at-point`. 

Do you think this could be beneficial? Looking forward to you thoughts on this. 

Best regards,
jgru