### PR TITLE
Modify zk-index-{next,previous}-line to always split vertically

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -602,7 +602,8 @@ Optionally refresh with FILES, using FORMAT-FN and SORT-FN."
   "Move to next line.
 If 'zk-index-auto-scroll' is non-nil, show note in other window."
   (interactive)
-  (let ((buffer (current-buffer)))
+  (let ((buffer (current-buffer))
+         (split-width-threshold nil))
     (if (save-excursion
           (forward-line)
           (and zk-index-auto-scroll
@@ -625,7 +626,8 @@ If 'zk-index-auto-scroll' is non-nil, show note in other window."
   "Move to previous line.
 If 'zk-index-auto-scroll' is non-nil, show note in other window."
   (interactive)
-  (let ((buffer (current-buffer)))
+  (let ((buffer (current-buffer))
+        (split-width-threshold nil))
   (if (save-excursion
           (forward-line -1)
           (and zk-index-auto-scroll


### PR DESCRIPTION
Dear Grant, 

this PR implements your fix of #3. As you intended by you, `zk-index-{next,previous}-line` will now always split vertically, since `split-width-threshold' is set locally to `nil`. This is needed for large frame sizes/displays, in order for zk-index to work correctly.

Thanks again for your troubleshooting and help on this!

Best regards
jgru