### PR TITLE
Refactor zk-index-(focus|search)-mode-line into a single function

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -198,6 +198,8 @@ it when not using `mode-line-misc-info'.")
 
 ;;; Declarations
 
+(defvar zk-index-last-sort-function nil)
+(defvar zk-index-last-format-function nil)
 (defvar zk-index-query-mode-line nil)
 (defvar zk-index-query-terms nil)
 (defvar zk-index-desktop-current nil)

--- a/zk-index.el
+++ b/zk-index.el
@@ -124,8 +124,7 @@ To quickly change this setting, call `zk-index-desktop-add-toggle'."
 ;;; ZK-Index Major Mode Settings
 
 (defvar zk-index-mode-line-orig nil
-  "Value of `mode-line-misc-info' at the start of the mode so we can reset to
-it when not using `mode-line-misc-info'.")
+  "Value of `mode-line-misc-info' at the start of mode.")
 
 (defvar zk-index-mode-map
   (let ((map (make-sparse-keymap)))
@@ -474,9 +473,10 @@ Optionally refresh with FILES, using FORMAT-FN, SORT-FN, BUF-NAME."
 ;;;; Low-level Query Functions
 
 (defvar zk-index-query-terms nil
-  "An ordered list of items in the form of (COMMAND . TERM), where COMMAND is
-'ZK-INDEX-FOCUS or 'ZK-INDEX-SEARCH, and TERM is the search string. More
-recent items are in the front.")
+  "Ordered list of current query terms.
+Takes form of (COMMAND . TERM), where COMMAND is 'ZK-INDEX-FOCUS
+or 'ZK-INDEX-SEARCH, and TERM is the query string. Recent
+items listed first.")
 
 (defun zk-index-query-files ()
   "Return narrowed list of notes, based on focus or search query."
@@ -510,8 +510,9 @@ recent items are in the front.")
         (error "No matches for \"%s\"" string))))
 
 (defun zk-index-query-mode-line (query-command string)
-  "Generate new mode line string after QUERY-COMMAND (either `zk-index-focus'
-or `zk-search-focus') narrowed the index with STRING"
+  "Generate new mode line after query.
+QUERY-COMMAND is either `zk-index-focus' or `zk-index-search',
+with query term STRING."
   (push (cons query-command string) zk-index-query-terms)
   ;; Sort the different terms into two lists
   (let (focused
@@ -538,11 +539,11 @@ or `zk-search-focus') narrowed the index with STRING"
                                 (split-string (symbol-name (car query)) "-")))
                               ": \""
                               (cdr query))))
-                ;; Put the last query type at the end
-                (sort (remq nil formatted)
-                      (lambda (a b)
-                        (not (equal (car a) query-command))))
-                "\" | ")
+                         ;; Put the last query type at the end
+                         (sort (remq nil formatted)
+                               (lambda (a _b)
+                                 (not (equal (car a) query-command))))
+                         "\" | ")
               "\"]"))))
 
 (defun zk-index--set-mode-line (string)

--- a/zk-index.el
+++ b/zk-index.el
@@ -198,9 +198,8 @@ it when not using `mode-line-misc-info'.")
 
 ;;; Declarations
 
-(defvar zk-index-last-sort-function nil)
-(defvar zk-index-last-format-function nil)
 (defvar zk-index-query-mode-line nil)
+(defvar zk-index-query-terms nil)
 (defvar zk-index-desktop-current nil)
 (defvar zk-search-history)
 
@@ -477,49 +476,29 @@ Optionally refresh with FILES, using FORMAT-FN, SORT-FN, BUF-NAME."
 'ZK-INDEX-FOCUS or 'ZK-INDEX-SEARCH, and TERM is the search string. More
 recent items are in the front.")
 
-(defvar zk-index-last-query nil
-  "Type of last query: either 'FOCUS or 'SEARCH.")
-
-(defvar zk-index-last-focus-terms nil
-  "A string containing all of the currently active focus query terms.")
-
-(defvar zk-index-last-search-terms nil
-  "A string containing all of the currently active search query terms.")
-
 (defun zk-index-query-files ()
   "Return narrowed list of notes, based on focus or search query."
   (let* ((command this-command)
          (scope (if (zk-index-narrowed-p (buffer-name))
                     (zk-index--current-id-list (buffer-name))
-                  (progn
-                    (setq zk-index-last-query nil)
-                    (zk--id-list))))
-         (string (read-string
-                  (cond
-                   ((eq command 'zk-index-focus)
-                    "Focus: ")
-                   ((eq command 'zk-index-search)
-                    "Search: "))
-                  nil 'zk-search-history))
+                  (setq zk-index-query-terms nil)
+                  (zk--id-list)))
+         (string (read-string (cond ((eq command 'zk-index-focus)
+                                     "Focus: ")
+                                    ((eq command 'zk-index-search)
+                                     "Search: "))
+                              nil 'zk-search-history))
          (query (cond
                  ((eq command 'zk-index-focus)
                   (zk--id-list string))
                  ((eq command 'zk-index-search)
                   (zk--grep-id-list string))))
-         (ids
-          (mapcar
-           (lambda (x)
-             (when (member x scope)
-               x))
-           query))
+         (ids (mapcar (lambda (x) (when (member x scope) x))
+                      query))
          (files (zk--parse-id 'file-path (remq nil ids))))
     (add-to-history 'zk-search-history string)
     (when files
-      (let ((mode-line
-             (cond ((eq command 'zk-index-focus)
-                    (zk-index-focus-mode-line string))
-                   ((eq command 'zk-index-search)
-                    (zk-index-search-mode-line string)))))
+      (let ((mode-line (zk-index-query-mode-line command string)))
         (setq zk-index-query-mode-line mode-line)
         (zk-index--set-mode-line mode-line)
         (zk-index--reset-mode-name)))
@@ -528,61 +507,41 @@ recent items are in the front.")
     (or files
         (error "No matches for \"%s\"" string))))
 
-(defun zk-index-focus-mode-line (string)
-  "Add STRING to modeline for `zk-index-focus'."
-  (cond
-   ;;same
-   ((eq zk-index-last-query 'focus)
-    ;;outcome
-    (setq zk-index-last-focus-terms
-          (if zk-index-last-focus-terms
-              (concat zk-index-last-focus-terms "\" + \"" string)
-            string))
-    (concat "[Focus: \"" zk-index-last-focus-terms "\"]"))
-   ;;mix
-   ((eq zk-index-last-query 'search)
-    ;;outcome
-    (setq zk-index-last-query 'focus)
-    (setq zk-index-last-focus-terms
-          (if zk-index-last-focus-terms
-              (concat zk-index-last-focus-terms "\" + \"" string)
-            string))
-    (concat "[Search: \"" zk-index-last-search-terms "\" |"
-            " Focus: \"" zk-index-last-focus-terms "\"]"))
-   ;;neither
-   ((not zk-index-last-query)
-    ;; outcome
-    (setq zk-index-last-query 'focus)
-    (setq zk-index-last-focus-terms string)
-    (concat "[Focus: \"" string "\"]"))))
-
-(defun zk-index-search-mode-line (string)
-  "Add STRING to modeline for `zk-index-search'."
-  (cond
-   ;;same
-   ((eq zk-index-last-query 'search)
-    ;;outcome
-    (setq zk-index-last-search-terms
-          (if zk-index-last-search-terms
-              (concat zk-index-last-search-terms "\" + \"" string)
-            string))
-    (concat "[Search: \"" zk-index-last-search-terms "\"]"))
-   ;;mix
-   ((eq zk-index-last-query 'focus)
-    ;;outcome
-    (setq zk-index-last-query 'search)
-    (setq zk-index-last-search-terms
-          (if zk-index-last-search-terms
-              (concat zk-index-last-search-terms "\" + \"" string)
-            string))
-    (concat "[Focus: \"" zk-index-last-focus-terms "\" |"
-            " Search: \"" zk-index-last-search-terms "\"]"))
-   ;;neither
-   ((not zk-index-last-query)
-    ;; outcome
-    (setq zk-index-last-query 'search)
-    (setq zk-index-last-search-terms string)
-    (concat "[Search: \"" string "\"]"))))
+(defun zk-index-query-mode-line (query-command string)
+  "Generate new mode line string after QUERY-COMMAND (either `zk-index-focus'
+or `zk-search-focus') narrowed the index with STRING"
+  (push (cons query-command string) zk-index-query-terms)
+  ;; Sort the different terms into two lists
+  (let (focused
+        searched)
+    (dolist (term zk-index-query-terms)
+      (if (equal (car term) 'zk-index-focus)
+          (push term focused)
+        (push term searched)))
+    ;; Format each list and update appropriate list
+    (let* ((formatted
+            (mapcar (lambda (term-list)
+                      (when term-list
+                        ;; (CMD . STRING)
+                        (cons (caar term-list)
+                              (mapconcat #'cdr term-list "\" + \""))))
+                    ;;      CAR     CDR
+                    (list focused searched))))
+      (concat "["
+              (mapconcat (lambda (query)
+                           (when query
+                             (concat
+                              (capitalize
+                               (caddr
+                                (split-string (symbol-name (car query)) "-")))
+                              ": \""
+                              (cdr query))))
+                ;; Put the last query type at the end
+                (sort (remq nil formatted)
+                      (lambda (a b)
+                        (not (equal (car a) query-command))))
+                "\" | ")
+              "\"]"))))
 
 (defun zk-index--set-mode-line (string)
   "Add STRING to mode-line in `zk-index-mode'."
@@ -593,8 +552,7 @@ recent items are in the front.")
   "Reset mode-line in `zk-index-mode'."
   (setq-local mode-line-misc-info zk-index-mode-line-orig)
   (setq zk-index-query-mode-line nil
-        zk-index-last-focus-terms nil
-        zk-index-last-search-terms nil))
+        zk-index-query-terms nil))
 
 (defun zk-index--current-id-list (buf-name)
   "Return list of IDs for index in BUF-NAME, as filepaths."

--- a/zk-index.el
+++ b/zk-index.el
@@ -123,10 +123,9 @@ To quickly change this setting, call `zk-index-desktop-add-toggle'."
 
 ;;; ZK-Index Major Mode Settings
 
-(defvar zk-index-last-query nil)
-(defvar zk-index-last-focus-terms nil)
-(defvar zk-index-last-search-terms nil)
-(defvar zk-index-mode-line-orig nil)
+(defvar zk-index-mode-line-orig nil
+  "Value of `mode-line-misc-info' at the start of the mode so we can reset to
+it when not using `mode-line-misc-info'.")
 
 (defvar zk-index-mode-map
   (let ((map (make-sparse-keymap)))
@@ -472,6 +471,20 @@ Optionally refresh with FILES, using FORMAT-FN, SORT-FN, BUF-NAME."
     (user-error "Not in a ZK-Index")))
 
 ;;;; Low-level Query Functions
+
+(defvar zk-index-query-terms nil
+  "An ordered list of items in the form of (COMMAND . TERM), where COMMAND is
+'ZK-INDEX-FOCUS or 'ZK-INDEX-SEARCH, and TERM is the search string. More
+recent items are in the front.")
+
+(defvar zk-index-last-query nil
+  "Type of last query: either 'FOCUS or 'SEARCH.")
+
+(defvar zk-index-last-focus-terms nil
+  "A string containing all of the currently active focus query terms.")
+
+(defvar zk-index-last-search-terms nil
+  "A string containing all of the currently active search query terms.")
 
 (defun zk-index-query-files ()
   "Return narrowed list of notes, based on focus or search query."


### PR DESCRIPTION
(Hi! After getting frustrated with my home-grown Deft-based Zettelkasten implementation, I came upon your package and have been adapting both my existing structure to Zk and also adding some minor extensions to Zk to make that possible. So far, Zk has been able to handle my ~6400 notes much better than Deft. Thanks for publishing the package!)

This refactoring is not strictly necessary, but Iʹm uneasy about near-duplicate functions that would require keeping any changes in sync, so I combined them into one function. I can see why you had two, though; it was a nice programming puzzle to replicate the functionality within one function. I also added doc strings to the relevant variables.