### PR TITLE
Add option (zk-directory-recursive) to find files recursively

### DIFF
--- a/zk.el
+++ b/zk.el
@@ -7,7 +7,7 @@
 ;; License: GPL-3.0-or-later
 ;; Version: 0.4
 ;; Homepage: https://github.com/localauthor/zk
-;; Package-Requires: ((emacs "24.4"))
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This program is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the Free

--- a/zk.el
+++ b/zk.el
@@ -5,7 +5,7 @@
 ;; Author: Grant Rosson <https://github.com/localauthor>
 ;; Created: January 4, 2022
 ;; License: GPL-3.0-or-later
-;; Version: 0.4
+;; Version: 0.5
 ;; Homepage: https://github.com/localauthor/zk
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -330,11 +330,11 @@ subdirectories of `zk-directory' (with the exception of those matching
           (if (not zk-directory-recursive)
               (directory-files zk-directory full regexp)
             (directory-files-recursively
-                    zk-directory regexp nil
-                    (lambda (dir)
-                      (not (string-match
-                            zk-directory-recursive-ignore-dir-regexp
-                            dir))))))
+             zk-directory regexp nil
+             (lambda (dir)
+               (not (string-match
+                     zk-directory-recursive-ignore-dir-regexp
+                     dir))))))
          (useful-files
           (remq nil (mapcar
                      (lambda (x)

--- a/zk.el
+++ b/zk.el
@@ -324,38 +324,32 @@ a regexp to replace the default, `zk-id-regexp'.
 
 If `zk-directory-recursive' is non-nil, then search recursively in
 subdirectories of `zk-directory' (with the exception of those matching
-`zk-directory-recursive-ignore-dir-regexp')."
+`zk-directory-recursive-ignore-dir-regexp') and return full file-paths."
   (let* ((regexp (or regexp zk-id-regexp))
-         (list
+         (files
           (if (not zk-directory-recursive)
               (directory-files zk-directory full regexp)
-            (let ((all-files
-                   (directory-files-recursively
+            (directory-files-recursively
                     zk-directory regexp nil
                     (lambda (dir)
                       (not (string-match
                             zk-directory-recursive-ignore-dir-regexp
                             dir))))))
-              (if full
-                  (mapcar #'expand-file-name all-files)
-                (mapcar (lambda (file)
-                          (file-relative-name file zk-directory))
-                        all-files)))))
-         (files (remq nil (mapcar
-                           (lambda (x)
-                             (when
-                                 (and (string-match (concat "\\(?1:"
-                                                            zk-id-regexp
-                                                            "\\).\\(?2:.*?\\)\\."
-                                                            zk-file-extension
-                                                            ".*")
-                                                    x)
-                                      (not (string-match-p
-                                            "^[.]\\|[#|~]$"
-                                            (file-name-nondirectory x))))
-                               x))
-                           list))))
-    files))
+         (useful-files
+          (remq nil (mapcar
+                     (lambda (x)
+                       (when (and (string-match (concat "\\(?1:"
+                                                        zk-id-regexp
+                                                        "\\).\\(?2:.*?\\)\\."
+                                                        zk-file-extension
+                                                        ".*")
+                                                x)
+                                  (not (string-match-p
+                                        "^[.]\\|[#|~]$"
+                                        (file-name-nondirectory x))))
+                         x))
+                     files))))
+    useful-files))
 
 (defun zk--current-notes-list ()
   "Return list of files for currently open notes."

--- a/zk.el
+++ b/zk.el
@@ -322,11 +322,12 @@ Excludes lockfiles, autosave files, and backup files. When FULL is
 non-nil, return full file-paths. If REGEXP is non-nil, it must be
 a regexp to replace the default, `zk-id-regexp'.
 
-If `zk-directory-recursive' is non-nil, then search recursively in
-subdirectories of `zk-directory' (with the exception of those matching
-`zk-directory-recursive-ignore-dir-regexp') and return full file-paths."
+When `zk-directory-recursive' is non-nil, searches recursively in
+subdirectories of `zk-directory' (except those matching
+`zk-directory-recursive-ignore-dir-regexp') and returns full
+file-paths."
   (let* ((regexp (or regexp zk-id-regexp))
-         (files
+         (list
           (if (not zk-directory-recursive)
               (directory-files zk-directory full regexp)
             (directory-files-recursively
@@ -335,7 +336,7 @@ subdirectories of `zk-directory' (with the exception of those matching
                (not (string-match
                      zk-directory-recursive-ignore-dir-regexp
                      dir))))))
-         (useful-files
+         (files
           (remq nil (mapcar
                      (lambda (x)
                        (when (and (string-match (concat "\\(?1:"
@@ -348,8 +349,8 @@ subdirectories of `zk-directory' (with the exception of those matching
                                         "^[.]\\|[#|~]$"
                                         (file-name-nondirectory x))))
                          x))
-                     files))))
-    useful-files))
+                     list))))
+    files))
 
 (defun zk--current-notes-list ()
   "Return list of files for currently open notes."

--- a/zk.el
+++ b/zk.el
@@ -338,8 +338,8 @@ subdirectories of `zk-directory' (with the exception of those matching
                             dir))))))
               (if full
                   (mapcar #'expand-file-name all-files)
-                (mapcar #'(lambda (file)
-                            (file-relative-name file zk-directory))
+                (mapcar (lambda (file)
+                          (file-relative-name file zk-directory))
                         all-files)))))
          (files (remq nil (mapcar
                            (lambda (x)

--- a/zk.el
+++ b/zk.el
@@ -83,12 +83,13 @@
 
 ;; Borrowed from Deft by Jason R. Blevins <jblevins@xbeta.org>
 (defcustom zk-directory-recursive nil
-  "Recursively search for files in subdirectories of `zk-directory'.")
+  "Recursively search for files in subdirectories of `zk-directory'."
+  :type 'boolean)
 
 (defcustom zk-directory-recursive-ignore-dir-regexp
   "\\(?:\\.\\|\\.\\.\\)$"
-  "Regular expression for subdirectories to be ignored while searching for
-files recursively, i.e. when ‘zk-directory-recursive’ is non-nil.")
+  "Regexp for subdirs to be ignored when ‘zk-directory-recursive’ is non-nil."
+  :type 'string)
 
 (defcustom zk-file-extension nil
   "The extension for zk files."


### PR DESCRIPTION
Having notes split into subdirectories --- for example, one for each year --- makes it easier to handle the files outside of Emacs and Zk ecosystem.