### PR TITLE
Introduce an option not to include title in the file name

### DIFF
--- a/README.org
+++ b/README.org
@@ -67,6 +67,10 @@ Each note is a separate file, named as follows: a unique ID number followed
 by the title of the note followed by the file extension (set in the variable
 =zk-extension=), e.g. "202012091130 On the origin of species.txt".
 
+Note: Like with many other aspects of ZK, both of these points are customizable with
+=zk-directory-recursive= and =zk-file-name-title-optional=, respectively. For simplicity's
+sake, this document describes the default format.
+
 ** IDs and Links
 
 The primary connector between notes is the simple link, which takes the form

--- a/zk-index.el
+++ b/zk-index.el
@@ -287,6 +287,7 @@ FILES must be a list of filepaths. If nil, all files in
               (zk-find-file-by-id zk-default-backlink)))
           (generate-new-buffer buf-name)
           (with-current-buffer buf-name
+            (setq default-directory (expand-file-name zk-directory))
             (zk-index-mode)
             (zk-index--sort list format-fn sort-fn)
             (setq truncate-lines t)

--- a/zk-index.el
+++ b/zk-index.el
@@ -250,33 +250,21 @@ by the ID and `%t' by the title. It can be a string, such as \"%t
 
 FILES must be a list of filepaths. If nil, all files in
 `zk-directory' will be returned as formatted candidates."
-  (let* ((zk-index-format (if zk-index-invisible-ids "%t %i"
+  (let* ((zk-index-format (if zk-index-invisible-ids
+                              "%t %i"
                             zk-index-format))
-         (format (or format
-                     zk-index-format))
-         (list (or files
-                   (zk--directory-files)))
+         (format (or format zk-index-format))
+         (list (or files (zk--directory-files)))
          (output))
-    (dolist (file list)
-      (progn
-        (string-match (concat "\\(?1:"
-                              zk-id-regexp
-                              "\\).\\(?2:.*?\\)\\."
-                              zk-file-extension
-                              ".*")
-                      file)
-        (let ((id (if zk-index-invisible-ids
-                      (propertize (match-string 1 file) 'invisible t)
-                    (match-string 1 file)))
-              (title (replace-regexp-in-string
-                      zk-file-name-separator
-                      " "
-                      (match-string 2 file))))
-          (when id
-            (push (format-spec format
-                               `((?i . ,id)(?t . ,title)))
-                  output)))))
-    output))
+    (dolist (file list output)
+      (let ((id (if zk-index-invisible-ids
+                    (propertize (zk--parse-file 'id file) 'invisible t)
+                  (zk--parse-file 'id file)))
+            (title (zk--parse-file 'title file)))
+        (when id
+          (push (format-spec format
+                             `((?i . ,id) (?t . ,title)))
+                output))))))
 
 ;;; Main Stack
 

--- a/zk.el
+++ b/zk.el
@@ -662,16 +662,16 @@ title."
   (read-only-mode -1)
   (let* ((id (zk--current-id))
          (file-title (zk--parse-file-name 'title id))
-         (header-title (progn
-                         (save-excursion
-                           (goto-char (point-min))
-                           (re-search-forward (concat id "."))
-                           (buffer-substring-no-properties
-                            (point)
-                            (line-end-position)))))
+         (header-title (save-excursion
+                         (goto-char (point-min))
+                         (re-search-forward (concat id "."))
+                         (buffer-substring-no-properties
+                          (point)
+                          (line-end-position))))
          (new-title
           (string-trim                  ;  trim [ \t\n\r]+ on both ends
-           (if (and (not zk-file-name-title-optional)
+           (if (and file-title
+                    (not zk-file-name-title-optional)
                     (not (string= file-title header-title))
                     (y-or-n-p
                      (format "Change title in filename from \"%s\" to \"%s\"? "
@@ -682,8 +682,8 @@ title."
     (when (not zk-file-name-title-optional)
       (let ((new-file (zk--id-file-path id new-title)))
         (rename-file buffer-file-name new-file t)
-        (set-visited-file-name new-file t t)
-        (save-buffer)))))
+        (set-visited-file-name new-file t t)))
+    (save-buffer)))
 
 ;;; Find File
 

--- a/zk.el
+++ b/zk.el
@@ -598,7 +598,10 @@ Optional TITLE argument."
                    (buffer-substring
                     (point)
                     (point-max)))))
-         (file-name (zk--id-file-path new-id title)))
+         (file-name (zk--id-file-path
+                     new-id
+                     (when (not zk-file-name-title-optional)
+                       title))))
     (unless orig-id
       (setq orig-id zk-default-backlink))
     (when (use-region-p)

--- a/zk.el
+++ b/zk.el
@@ -513,9 +513,11 @@ On each file, call `zk--parse-file-function' and collect the results."
 file-path, as a string.A note's title is understood to be the portion of its
 filename following the zk ID, in the format `zk-id-regexp', and preceding the
 file extension. This is the default value of `zk--parse-file-function'."
-  (when (string-match (concat "\\(?1:"
-                              zk-id-regexp
-                              "\\).\\(?2:.*?\\)\\."
+  (when (string-match (concat "\\(?1:" zk-id-regexp "\\)"
+                              (if zk-file-name-title-optional
+                                  ""
+                                zk-file-name-separator)
+                              "\\(?2:.*?\\)\\."
                               zk-file-extension)
                       file)
     (replace-regexp-in-string zk-file-name-separator " "

--- a/zk.el
+++ b/zk.el
@@ -639,7 +639,7 @@ title."
   (interactive)
   (read-only-mode -1)
   (let* ((id (zk--current-id))
-         (file-title (zk--parse-id 'title id))
+         (file-title (zk--parse-file-name 'title id))
          (header-title (progn
                          (save-excursion
                            (goto-char (point-min))
@@ -653,8 +653,7 @@ title."
             (setq new-title header-title)
           (setq new-title (read-string "New title: " file-title)))
       (setq new-title (read-string "New title: " file-title)))
-    (when (string-match "\n" new-title)
-      (setq new-title (replace-regexp-in-string "\n" "" new-title)))
+    (setq new-title (string-trim new-title)) ; trims [ \t\n\r]+ on both ends
     (save-excursion
       (goto-char (point-min))
       (re-search-forward id)

--- a/zk.el
+++ b/zk.el
@@ -661,7 +661,7 @@ title."
   (interactive)
   (read-only-mode -1)
   (let* ((id (zk--current-id))
-         (file-title (zk--parse-file-name 'title id))
+         (file-title (zk--parse-file-name 'title buffer-file-name))
          (header-title (save-excursion
                          (goto-char (point-min))
                          (re-search-forward (concat id "."))

--- a/zk.el
+++ b/zk.el
@@ -315,11 +315,12 @@ that instead."
       (funcall zk--id-file-path-function)
     (replace-regexp-in-string " "
                               zk-file-name-separator
-                              (format "%s/%s%s%s.%s"
+                              (format "%s/%s%s.%s"
                                       zk-directory
                                       id
-                                      zk-file-name-separator
-                                      title
+                                      (if title
+                                          (concat zk-file-name-separator title)
+                                        "")
                                       zk-file-extension))))
 
 (defun zk--id-list (&optional str zk-alist)

--- a/zk.el
+++ b/zk.el
@@ -107,14 +107,14 @@ rendered with spaces."
 
 (defcustom zk-file-name-id-only nil
   "If non-nil, file names consist of IDs only without the title.
-Note: If you change this value, also set `zk--parse-file-function' to
-`zk--parse-file-header' or another function that can return the note's
+Note: If you change this value, also set `zk-parse-file-function' to
+`zk-parse-file-header' or another function that can return the note's
 title."
   :type 'boolean)
 
-(defcustom zk--parse-file-function #'zk--parse-file-name
-  "A function taking two arguments, TARGET and FILE, which returns either 'id
-or 'title (as specified by TARGET) for the given FILE."
+(defcustom zk-parse-file-function #'zk-parse-file-name
+  "Function called by `zk--parse-file' to return id or title of given FILE.
+Must take two arguments TARGET (either `id or `title) and FILE."
   :type 'function)
 
 (defcustom zk--id-file-path-function #'zk--id-file-path
@@ -505,10 +505,10 @@ in an internal loop."
 (defun zk--parse-file (target file-or-files)
   "Return TARGET, either `id or `title, from FILE-OR-FILES.
 Takes a single file-path, as a string, or a list of file-paths.
-On each file, call `zk--parse-file-function' and collect the results."
+On each file, call `zk-parse-file-function' and collect the results."
   (let ((result
          (mapcar (lambda (file)
-                   (funcall zk--parse-file-function target file))
+                   (funcall zk-parse-file-function target file))
                  (if (listp file-or-files)
                      file-or-files
                    (list file-or-files)))))
@@ -516,11 +516,12 @@ On each file, call `zk--parse-file-function' and collect the results."
         (car result)
       result)))
 
-(defun zk--parse-file-name (target file)
-  "Return TARGET, either 'id or 'title, from the given FILE, a single
-file-path, as a string. A note's title is understood to be the portion of its
-filename following the zk ID, in the format `zk-id-regexp', and preceding the
-file extension. This is the default value of `zk--parse-file-function'."
+(defun zk-parse-file-name (target file)
+  "Return TARGET, either `id or `title, from the given FILE.
+A note's title is understood to be the portion of its filename
+following the zk ID, in the format `zk-id-regexp', and preceding
+the file extension. This is the default value of
+`zk-parse-file-function'."
   (when (string-match (concat "\\(?1:" zk-id-regexp "\\)"
                               zk-file-name-separator
                               (if zk-file-name-id-only
@@ -536,9 +537,9 @@ file extension. This is the default value of `zk--parse-file-function'."
                                           " "
                                           (match-string 2 file)))))))
 
-(defun zk--parse-file-header (target file)
-  "Return TARGET, either 'id or 'title, from the given FILE, a single
-file-path, as a string. Unlike `zk--parse-file-name', attempt to get the note
+(defun zk-parse-file-header (target file)
+  "Return TARGET, either `id or `title, from the given FILE.
+Unlike `zk-parse-file-name', attempt to get the note
 title from the file header."
   (when (string-match zk-id-regexp file)
     (let ((id (match-string 0 file)))
@@ -681,8 +682,8 @@ title."
   (interactive)
   (read-only-mode -1)
   (let* ((id (zk--current-id))
-         (file-title (zk--parse-file-name 'title buffer-file-name))
-         (header-title (zk--parse-file-header 'title buffer-file-name))
+         (file-title (zk-parse-file-name 'title buffer-file-name))
+         (header-title (zk-parse-file-header 'title buffer-file-name))
          (new-title
           (string-trim                  ;  trim [ \t\n\r]+ on both ends
            (if (and file-title

--- a/zk.el
+++ b/zk.el
@@ -44,11 +44,12 @@
 ;; Linking to such a note involves nothing more than placing the string
 ;; [[202012091130]] into another note in the directory.
 
-;; A note's filename is constructed as follows: the zk ID number followed by
-;; the title of the note followed by the file extension, e.g. "202012091130
-;; On the origin of species.txt". A key consequence of this ID/linking scheme
-;; is that a note's title can change without any existing links to the note
-;; being broken, wherever they might be in the directory.
+;; By default (see `zk-file-name-title-optional'), note's filename is
+;; constructed as follows: the zk ID number followed by the title of the note
+;; followed by the file extension, e.g. "202012091130 On the origin of
+;; species.txt". A key consequence of this ID/linking scheme is that a note's
+;; title can change without any existing links to the note being broken,
+;; wherever they might be in the directory.
 
 ;; The directory is a single folder containing all notes.
 
@@ -106,8 +107,8 @@ rendered with spaces."
 
 (defcustom zk-file-name-title-optional nil
   "If non-nil, file names can consist of IDs only, like \"202012341234\".
-For things to work as expected, also need to set `zk--parse-file-function'
-so it can return the title for a given file."
+Note: If you change this value, also set `zk--parse-file-function' to a
+function that can return the title for a given file."
   :type 'boolean)
 
 (defcustom zk--parse-file-function #'zk--parse-file-name

--- a/zk.el
+++ b/zk.el
@@ -544,14 +544,15 @@ title from the file header."
     (let ((id (match-string 0 file)))
       (if (eql target 'id)
           id
-        (with-temp-buffer
-          (insert-file-contents file)
-          (goto-char (point-min))
-          (when (re-search-forward
-                 (concat id (regexp-quote zk-file-name-separator))
-                 nil t)
-            (buffer-substring-no-properties
-             (match-end 0) (line-end-position))))))))
+        (when (file-exists-p file)
+          (with-temp-buffer
+            (insert-file-contents file)
+            (goto-char (point-min))
+            (when (re-search-forward
+                   (concat id (regexp-quote zk-file-name-separator))
+                   nil t)
+              (buffer-substring-no-properties
+               (match-end 0) (line-end-position)))))))))
 
 ;;; Buttons
 

--- a/zk.el
+++ b/zk.el
@@ -276,20 +276,21 @@ Adds zk-id as an Embark target, and adds `zk-id-map' and
 
 ;;; Low-Level Functions
 
-(defun zk-file-p (&optional file)
-  "Return t if `current-buffer' is a zk-file.
-With optional argument FILE."
-  (let* ((file (if (stringp file) file
-                 (car file)))
-         (dir (or file
-                  default-directory))
-         (file-name (or file
-                        buffer-file-name)))
-    (when (and file-name
-               (file-exists-p file-name)
-               (file-in-directory-p dir zk-directory)
-               (string-match-p zk-id-regexp file-name))
-      t)))
+(defun zk-file-p (&optional file strict)
+  "Return t if FILE is a zk-file.
+If FILE is not given, get it from `buffer-file-name'. If STRICT is non-nil,
+make sure the file is in `zk-directory', otherwise just match against
+`zk-id-regexp'."
+  (let ((file (cond ((stringp file) file)
+                    ((null file) buffer-file-name)
+                    ((listp file) (car file))
+                    (t
+                     (signal 'wrong-type-argument '(file))))))
+    (and file
+         (file-exists-p file)
+         (string-match-p zk-id-regexp file)
+         (or (not strict)
+             (file-in-directory-p file zk-directory)))))
 
 (defun zk--generate-id ()
   "Generate and return a zk ID.

--- a/zk.el
+++ b/zk.el
@@ -44,12 +44,12 @@
 ;; Linking to such a note involves nothing more than placing the string
 ;; [[202012091130]] into another note in the directory.
 
-;; By default (see `zk-file-name-title-optional'), note's filename is
-;; constructed as follows: the zk ID number followed by the title of the note
-;; followed by the file extension, e.g. "202012091130 On the origin of
-;; species.txt". A key consequence of this ID/linking scheme is that a note's
-;; title can change without any existing links to the note being broken,
-;; wherever they might be in the directory.
+;; By default (see `zk-file-name-id-only'), note's filename is constructed as
+;; follows: the zk ID number followed by the title of the note followed by
+;; the file extension, e.g. "202012091130 On the origin of species.txt". A
+;; key consequence of this ID/linking scheme is that a note's title can
+;; change without any existing links to the note being broken, wherever they
+;; might be in the directory.
 
 ;; The directory is a single folder containing all notes.
 
@@ -105,8 +105,8 @@ for example, the file-name will be in the form
 rendered with spaces."
   :type 'string)
 
-(defcustom zk-file-name-title-optional nil
-  "If non-nil, file names can consist of IDs only, like \"202012341234\".
+(defcustom zk-file-name-id-only nil
+  "If non-nil, file names consist of IDs only without the title.
 Note: If you change this value, also set `zk--parse-file-function' to a
 function that can return the title for a given file."
   :type 'boolean)
@@ -521,7 +521,7 @@ file-path, as a string.A note's title is understood to be the portion of its
 filename following the zk ID, in the format `zk-id-regexp', and preceding the
 file extension. This is the default value of `zk--parse-file-function'."
   (when (string-match (concat "\\(?1:" zk-id-regexp "\\)"
-                              (if zk-file-name-title-optional
+                              (if zk-file-name-id-only
                                   ""
                                 zk-file-name-separator)
                               "\\(?2:.*?\\)\\."
@@ -609,7 +609,7 @@ Optional TITLE argument."
                     (point-max)))))
          (file-name (zk--id-file-path
                      new-id
-                     (when (not zk-file-name-title-optional)
+                     (when (not zk-file-name-id-only)
                        title))))
     (unless orig-id
       (setq orig-id zk-default-backlink))
@@ -679,7 +679,7 @@ title."
                header-title
              (read-string "New title: " (or file-title header-title))))))
     (funcall zk-update-note-header-function new-title id)
-    (when (not zk-file-name-title-optional)
+    (when (not zk-file-name-id-only)
       (let ((new-file (zk--id-file-path id new-title)))
         (rename-file buffer-file-name new-file t)
         (set-visited-file-name new-file t t)))

--- a/zk.el
+++ b/zk.el
@@ -104,6 +104,17 @@ for example, the file-name will be in the form
 rendered with spaces."
   :type 'string)
 
+(defcustom zk-file-name-title-optional nil
+  "If non-nil, file names can consist of IDs only, like \"202012341234\".
+For things to work as expected, also need to set `zk--parse-file-function'
+so it can return the title for a given file."
+  :type 'boolean)
+
+(defcustom zk--parse-file-function #'zk--parse-file
+  "A function taking two arguments, TARGET and FILE, which returns either 'id
+or 'title (as specified by TARGET) for the given FILE."
+  :type 'function)
+
 (defcustom zk-enable-link-buttons t
   "When non-nil, valid zk-id links will be clickable buttons.
 Allows `zk-make-link-buttons' to be added to `find-file-hook', so

--- a/zk.el
+++ b/zk.el
@@ -116,6 +116,10 @@ function that can return the title for a given file."
 or 'title (as specified by TARGET) for the given FILE."
   :type 'function)
 
+(defcustom zk--id-file-path-function #'zk--id-file-path
+  "Given a zk ID and TITLE, return a full file path."
+  :type 'function)
+
 (defcustom zk-enable-link-buttons t
   "When non-nil, valid zk-id links will be clickable buttons.
 Allows `zk-make-link-buttons' to be added to `find-file-hook', so
@@ -304,15 +308,19 @@ The ID is created using `zk-id-time-string-format'."
 
 (defun zk--id-file-path (id title)
   "Given a zk ID and TITLE, return a full file path based on `zk-directory',
-`zk-file-name-separator', and `zk-file-name-separator'."
-  (replace-regexp-in-string " "
-                            zk-file-name-separator
-                            (format "%s/%s%s%s.%s"
-                                    zk-directory
-                                    id
-                                    zk-file-name-separator
-                                    title
-                                    zk-file-extension)))
+`zk-file-name-separator', and `zk-file-name-separator'. If
+`zk--id-file-path-function' is different from the current function, call
+that instead."
+  (if (not (equal zk--id-file-path-function 'zk--id-file-path))
+      (funcall zk--id-file-path-function)
+    (replace-regexp-in-string " "
+                              zk-file-name-separator
+                              (format "%s/%s%s%s.%s"
+                                      zk-directory
+                                      id
+                                      zk-file-name-separator
+                                      title
+                                      zk-file-extension))))
 
 (defun zk--id-list (&optional str zk-alist)
   "Return a list of zk IDs for notes in `zk-directory'.

--- a/zk.el
+++ b/zk.el
@@ -302,6 +302,18 @@ The ID is created using `zk-id-time-string-format'."
       (setq id (number-to-string id)))
     id))
 
+(defun zk--id-file-path (id title)
+  "Given a zk ID and TITLE, return a full file path based on `zk-directory',
+`zk-file-name-separator', and `zk-file-name-separator'."
+  (replace-regexp-in-string " "
+                            zk-file-name-separator
+                            (format "%s/%s%s%s.%s"
+                                    zk-directory
+                                    id
+                                    zk-file-name-separator
+                                    title
+                                    zk-file-extension)))
+
 (defun zk--id-list (&optional str zk-alist)
   "Return a list of zk IDs for notes in `zk-directory'.
 Optional search for regexp STR in note title, case-insenstive.
@@ -577,15 +589,7 @@ Optional TITLE argument."
                    (buffer-substring
                     (point)
                     (point-max)))))
-         (file-name (replace-regexp-in-string " "
-                                              zk-file-name-separator
-                                              (concat
-                                               (format "%s/%s%s%s.%s"
-                                                       zk-directory
-                                                       new-id
-                                                       zk-file-name-separator
-                                                       title
-                                                       zk-file-extension)))))
+         (file-name (zk--id-file-path new-id title)))
     (unless orig-id
       (setq orig-id zk-default-backlink))
     (when (use-region-p)
@@ -649,15 +653,7 @@ title."
       (re-search-forward " ")
       (delete-region (point) (line-end-position))
       (insert new-title))
-    (let ((new-file (concat
-                     zk-directory "/"
-                     id
-                     zk-file-name-separator
-                     (replace-regexp-in-string
-                      " "
-                      zk-file-name-separator
-                      new-title)
-                     "." zk-file-extension)))
+    (let ((new-file (zk--id-file-path id new-title)))
       (rename-file buffer-file-name new-file t)
       (set-visited-file-name new-file t t)
       (save-buffer))))

--- a/zk.el
+++ b/zk.el
@@ -518,21 +518,23 @@ On each file, call `zk--parse-file-function' and collect the results."
 
 (defun zk--parse-file-name (target file)
   "Return TARGET, either 'id or 'title, from the given FILE, a single
-file-path, as a string.A note's title is understood to be the portion of its
+file-path, as a string. A note's title is understood to be the portion of its
 filename following the zk ID, in the format `zk-id-regexp', and preceding the
 file extension. This is the default value of `zk--parse-file-function'."
   (when (string-match (concat "\\(?1:" zk-id-regexp "\\)"
+                              zk-file-name-separator
                               (if zk-file-name-id-only
-                                  ""
-                                zk-file-name-separator)
+                                  "*"   ; i.e. separator is optional
+                                "")
                               "\\(?2:.*?\\)\\."
                               zk-file-extension)
                       file)
-    (replace-regexp-in-string zk-file-name-separator " "
-                              (match-string (pcase target
-                                              ('id    1)
-                                              ('title 2))
-                                            file))))
+    (pcase target
+      ('id    (match-string 1 file))
+      ('title (unless (string-empty-p (match-string 2 file))
+                (replace-regexp-in-string zk-file-name-separator
+                                          " "
+                                          (match-string 2 file)))))))
 
 (defun zk--parse-file-header (target file)
   "Return TARGET, either 'id or 'title, from the given FILE, a single

--- a/zk.el
+++ b/zk.el
@@ -347,22 +347,15 @@ file-paths."
              (lambda (dir)
                (not (string-match
                      zk-directory-recursive-ignore-dir-regexp
-                     dir))))))
-         (files
-          (remq nil (mapcar
-                     (lambda (x)
-                       (when (and (string-match (concat "\\(?1:"
-                                                        zk-id-regexp
-                                                        "\\).\\(?2:.*?\\)\\."
-                                                        zk-file-extension
-                                                        ".*")
-                                                x)
-                                  (not (string-match-p
-                                        "^[.]\\|[#|~]$"
-                                        (file-name-nondirectory x))))
-                         x))
-                     list))))
-    files))
+                     dir)))))))
+    (remq nil (mapcar
+               (lambda (x)
+                 (when (and (zk-file-p x)
+                            (not (string-match-p
+                                  "^[.]\\|[#|~]$"
+                                  (file-name-nondirectory x))))
+                   x))
+               list))))
 
 (defun zk--current-notes-list ()
   "Return list of files for currently open notes."

--- a/zk.el
+++ b/zk.el
@@ -684,7 +684,7 @@ title."
          (new-title
           (string-trim                  ;  trim [ \t\n\r]+ on both ends
            (if (and file-title
-                    (not zk-file-name-title-optional)
+                    (not zk-file-name-id-only)
                     (not (string= file-title header-title))
                     (y-or-n-p
                      (format "Change title in filename from \"%s\" to \"%s\"? "

--- a/zk.el
+++ b/zk.el
@@ -117,7 +117,7 @@ title."
 Must take two arguments TARGET (either `id or `title) and FILE."
   :type 'function)
 
-(defcustom zk--id-file-path-function #'zk--id-file-path
+(defcustom zk-new-file-path-function #'zk-new-file-path
   "Given a zk ID and TITLE, return a full file path."
   :type 'function)
 
@@ -314,22 +314,20 @@ The ID is created using `zk-id-time-string-format'."
       (setq id (number-to-string id)))
     id))
 
-(defun zk--id-file-path (id title)
-  "Given a zk ID and TITLE, return a full file path based on `zk-directory',
-`zk-file-name-separator', and `zk-file-name-separator'. If
-`zk--id-file-path-function' is different from the current function, call
-that instead."
-  (if (not (equal zk--id-file-path-function 'zk--id-file-path))
-      (funcall zk--id-file-path-function)
-    (replace-regexp-in-string " "
-                              zk-file-name-separator
-                              (format "%s/%s%s.%s"
-                                      zk-directory
-                                      id
-                                      (if title
-                                          (concat zk-file-name-separator title)
-                                        "")
-                                      zk-file-extension))))
+(defun zk-new-file-path (id title)
+  "Generate file-path for new note.
+Takes an ID and TITLE and returns a full file path, based on
+values of `zk-directory', `zk-file-name-separator', and
+`zk-file-name-separator'."
+  (replace-regexp-in-string " "
+                            zk-file-name-separator
+                            (format "%s/%s%s.%s"
+                                    zk-directory
+                                    id
+                                    (if title
+                                        (concat zk-file-name-separator title)
+                                      "")
+                                    zk-file-extension)))
 
 (defun zk--id-list (&optional str zk-alist)
   "Return a list of zk IDs for notes in `zk-directory'.
@@ -628,10 +626,10 @@ Optional TITLE argument."
                    (buffer-substring
                     (point)
                     (point-max)))))
-         (file-name (zk--id-file-path
-                     new-id
-                     (when (not zk-file-name-id-only)
-                       title))))
+         (file-name (funcall zk-new-file-path-function
+                             new-id
+                             (when (not zk-file-name-id-only)
+                               title))))
     (unless orig-id
       (setq orig-id zk-default-backlink))
     (when (use-region-p)
@@ -698,7 +696,7 @@ title."
     ;; with the new title even if `zk-file-name-id-only' is non-nil.
     (when (or file-title
               (not zk-file-name-id-only))
-      (let ((new-file (zk--id-file-path id new-title)))
+      (let ((new-file (funcall zk-new-file-path-function id new-title)))
         (rename-file buffer-file-name new-file t)
         (set-visited-file-name new-file t t)))
     (save-buffer)))

--- a/zk.el
+++ b/zk.el
@@ -301,6 +301,7 @@ otherwise just match against `zk-id-regexp'."
                      (signal 'wrong-type-argument '(file))))))
     (and file
          (file-exists-p file)
+         (string-match-p zk-file-extension (file-name-extension file))
          (string-match-p zk-id-regexp file)
          (or (not strict)
              (file-in-directory-p file zk-directory)))))

--- a/zk.el
+++ b/zk.el
@@ -152,6 +152,13 @@ those corresponding values from `zk-new-note' available for
 insertion. See `zk-new-note-header' for an example."
   :type 'function)
 
+(defcustom zk-update-note-header-function #'zk-update-note-header
+  "Function called by `zk-rename-note' to udpate the header in an existing
+note. A user-defined function should locate the existing header and modify it
+according to the arguments ID and NEW-TITLE passed to it. See
+`zk-update-note-header' for an example."
+  :type 'function)
+
 (defcustom zk-new-note-link-insert 'ask
   "Should `zk-new-note' insert link to new note at point?
 
@@ -671,7 +678,7 @@ title."
                              file-title header-title)))
                header-title
              (read-string "New title: " (or file-title header-title))))))
-    (zk-update-note-header new-title id)
+    (funcall zk-update-note-header-function new-title id)
     (when (not zk-file-name-title-optional)
       (let ((new-file (zk--id-file-path id new-title)))
         (rename-file buffer-file-name new-file t)

--- a/zk.el
+++ b/zk.el
@@ -686,7 +686,6 @@ title."
          (new-title
           (string-trim                  ;  trim [ \t\n\r]+ on both ends
            (if (and file-title
-                    (not zk-file-name-id-only)
                     (not (string= file-title header-title))
                     (y-or-n-p
                      (format "Change title in filename from \"%s\" to \"%s\"? "
@@ -694,7 +693,10 @@ title."
                header-title
              (read-string "New title: " (or file-title header-title))))))
     (funcall zk-update-note-header-function new-title id)
-    (when (not zk-file-name-id-only)
+    ;; If the file name /does/ contain a title, do rename the file
+    ;; with the new title even if `zk-file-name-id-only' is non-nil.
+    (when (or file-title
+              (not zk-file-name-id-only))
       (let ((new-file (zk--id-file-path id new-title)))
         (rename-file buffer-file-name new-file t)
         (set-visited-file-name new-file t t)))

--- a/zk.el
+++ b/zk.el
@@ -154,10 +154,10 @@ insertion. See `zk-new-note-header' for an example."
   :type 'function)
 
 (defcustom zk-update-note-header-function #'zk-update-note-header
-  "Function called by `zk-rename-note' to udpate the header in an existing
-note. A user-defined function should locate the existing header and modify it
-according to the arguments ID and NEW-TITLE passed to it. See
-`zk-update-note-header' for an example."
+  "Function called by `zk-rename-note' to update title in header.
+A user-defined function should locate the existing header and
+modify it according to the arguments ID and NEW-TITLE passed to
+it. See `zk-update-note-header' for an example."
   :type 'function)
 
 (defcustom zk-new-note-link-insert 'ask

--- a/zk.el
+++ b/zk.el
@@ -279,9 +279,9 @@ Adds zk-id as an Embark target, and adds `zk-id-map' and
 
 (defun zk-file-p (&optional file strict)
   "Return t if FILE is a zk-file.
-If FILE is not given, get it from `buffer-file-name'. If STRICT is non-nil,
-make sure the file is in `zk-directory', otherwise just match against
-`zk-id-regexp'."
+If FILE is not given, get it from variable `buffer-file-name'. If
+STRICT is non-nil, make sure the file is in `zk-directory',
+otherwise just match against `zk-id-regexp'."
   (let ((file (cond ((stringp file) file)
                     ((null file) buffer-file-name)
                     ((listp file) (car file))


### PR DESCRIPTION
I keep the note's title in the note header itself, which while has some disadvantages when it comes to finding notes outside of Emacs/Zk, also means I don't have to rename files to change titles. This is useful largely because I keep my Zettelkasten in a git repository. Since git doesn't keep track of file renames, but rather tries to guess based on file content, renaming files is inconvenient if one wants to be able to trace changes despite renames.

As far as I can tell, there is little performance impact (but also see the other pull request about improving performance of z-file-p). I also use Zk-index, and everything works as expected. Just looking at references to titles in the code, nothing else should be affected either.