### PR TITLE
Change zk-index to set Emacs default-directory to zk-directory

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -299,6 +299,7 @@ FILES must be a list of filepaths. If nil, all files in
               (zk-find-file-by-id zk-default-backlink)))
           (generate-new-buffer buf-name)
           (with-current-buffer buf-name
+            (setq default-directory (expand-file-name zk-directory))
             (zk-index-mode)
             (zk-index--sort list format-fn sort-fn)
             (setq truncate-lines t)


### PR DESCRIPTION
This allows easy access to zk-directory from the zk-index buffer by invoking dired or magit-status, for example.