### PR TITLE
Bugfix: Change zk-link-regexp to macro of the same name

### DIFF
--- a/README.org
+++ b/README.org
@@ -225,7 +225,7 @@ link type, as follows:
 #+begin_src emacs-lisp
 (defun zk-link-hint--zk-link-at-point-p ()
   "Return the id of the zk-link at point or nil."
-  (thing-at-point-looking-at zk-link-regexp))
+  (thing-at-point-looking-at (zk-link-regexp)))
 
 (defun zk-link-hint--next-zk-link (&optional bound)
   "Find the next zk-link.

--- a/zk-index.el
+++ b/zk-index.el
@@ -892,16 +892,16 @@ If `zk-index-auto-scroll' is non-nil, show note in other window."
                   (when zk-index-invisible-ids
                     (beginning-of-line)
                     ;; find zk-links and plain zk-ids
-                    (if (re-search-forward zk-link-regexp (line-end-position) t)
+                    (if (re-search-forward (zk-link-regexp) (line-end-position) t)
                         (replace-match
                          (propertize (match-string 0) 'invisible t) nil t)
                       (progn
                         (re-search-forward id)
                         (replace-match
-                          (propertize id
-                                      'read-only t
-                                      'front-sticky t
-                                      'rear-nonsticky t))
+                         (propertize id
+                                     'read-only t
+                                     'front-sticky t
+                                     'rear-nonsticky t))
                         ;; enable invisibility in org-mode
                         (overlay-put
                          (make-overlay (match-beginning 0) (match-end 0))

--- a/zk-link-hint.el
+++ b/zk-link-hint.el
@@ -40,7 +40,7 @@
 (defun zk-link-hint--zk-link-at-point-p ()
   "Return the ID for the zk-link at the point or nil."
   (and (zk--id-at-point)
-       (thing-at-point-looking-at zk-link-regexp)))
+       (thing-at-point-looking-at (zk-link-regexp))))
 
 (defun zk-link-hint--next-zk-link (bound)
   "Find the next zk-link.

--- a/zk-org-link.el
+++ b/zk-org-link.el
@@ -53,7 +53,6 @@
 ;; Set up org-style link format by setting variables
 (setq zk-link-format "[[zk:%s]]")
 (setq zk-link-and-title-format "[[zk:%i][%t]]")
-(setq zk-link-regexp (format (regexp-quote zk-link-format) zk-id-regexp))
 (setq zk-enable-link-buttons nil)
 
 (defun zk-org-link--follow (id)

--- a/zk.el
+++ b/zk.el
@@ -539,12 +539,15 @@ Adds `zk-make-link-buttons' to `find-file-hook.'"
   (interactive)
   (when (and (zk-file-p)
              zk-enable-link-buttons)
-    (save-excursion
-      (goto-char (point-min))
-      (while (re-search-forward (zk-link-regexp) nil t)
-        (let ((beg (match-beginning 1))
-              (end (match-end 1)))
-          (make-button beg end 'type 'zk-link))))))
+    (let ((ids (zk--id-list)))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward (zk-link-regexp) nil t)
+          (let ((beg (match-beginning 1))
+                (end (match-end 1))
+                (id (match-string-no-properties 1)))
+            (when (member id ids)
+              (make-button beg end 'type 'zk-link))))))))
 
 (defun zk-make-button-before-point ()
   "Find `zk-link-regexp' before point and make it a zk-link button."
@@ -722,15 +725,21 @@ Optionally call a custom function by setting the variable
 
 (defun zk--links-in-note-list ()
   "Return list of zk files that are linked from the current buffer."
-  (let (id-list)
+  (let ((zk-ids (zk--id-list))
+        id-list)
     (save-buffer)
     (save-excursion
       (goto-char (point-min))
       (while (re-search-forward (zk-link-regexp) nil t)
-        (push (match-string-no-properties 1) id-list)))
-    (if (null id-list)
-        (message "No zk-links in note")
-      (zk--parse-ids 'file-path (delete-dups id-list)))))
+        (if (member (match-string-no-properties 1) zk-ids)
+            (push (match-string-no-properties 1) id-list))))
+    (cond ((null id-list)
+           (error "No zk-links in note"))
+          ((eq 1 (length id-list))
+           (list (zk--parse-id 'file-path id-list)))
+          (t
+           (zk--parse-id 'file-path (delete-dups id-list))))))
+
 
 ;;;###autoload
 (defun zk-links-in-note ()

--- a/zk.el
+++ b/zk.el
@@ -183,6 +183,12 @@ Used in conjunction with `format', the string `%s' will be
 replaced by a note's ID."
   :type 'string)
 
+;; This needs to be a macro in order to reflect user changes to the variables.
+(defmacro zk-link-regexp ()
+  "Returns the regexp matching a zk link based on `zk-link-format' and
+`zk-id-regexp'."
+  `(format (regexp-quote ,zk-link-format) ,zk-id-regexp))
+
 (defcustom zk-link-and-title t
   "Should `zk-insert-link' insert both link and title?
 
@@ -220,8 +226,6 @@ See `zk-current-notes' for details."
 The string `%t' will be replaced by the note's title and `%i'
 will be replaced by its ID."
   :type 'string)
-
-(defvar zk-link-regexp (format (regexp-quote zk-link-format) zk-id-regexp))
 
 (defvar zk-file-history nil)
 (defvar zk-search-history nil)
@@ -429,7 +433,7 @@ supplied. Can take a PROMPT argument."
   "Return ID at point."
   (cond ((thing-at-point-looking-at zk-id-regexp)
          (match-string-no-properties 0))
-        ((thing-at-point-looking-at zk-link-regexp)
+        ((thing-at-point-looking-at (zk-link-regexp))
          (match-string-no-properties 1))))
 
 (defun zk--alist ()
@@ -531,25 +535,22 @@ Adds `zk-make-link-buttons' to `find-file-hook.'"
                     (button-at pos)))))))
 
 (defun zk-make-link-buttons ()
-  "Make zk-link-regexps in current buffer into zk-link buttons."
+  "Make `zk-link-regexp's in current buffer into zk-link buttons."
   (interactive)
   (when (and (zk-file-p)
              zk-enable-link-buttons)
-    (let ((ids (zk--id-list)))
-      (save-excursion
-        (goto-char (point-min))
-        (while (re-search-forward zk-link-regexp nil t)
-          (let ((beg (match-beginning 1))
-                (end (match-end 1))
-                (id (match-string-no-properties 1)))
-            (when (member id ids)
-              (make-button beg end 'type 'zk-link))))))))
+    (save-excursion
+      (goto-char (point-min))
+      (while (re-search-forward (zk-link-regexp) nil t)
+        (let ((beg (match-beginning 1))
+              (end (match-end 1)))
+          (make-button beg end 'type 'zk-link))))))
 
 (defun zk-make-button-before-point ()
   "Find `zk-link-regexp' before point and make it a zk-link button."
   (interactive)
   (save-excursion
-    (re-search-backward zk-link-regexp (line-beginning-position))
+    (re-search-backward (zk-link-regexp) (line-beginning-position))
     (make-button (match-beginning 1) (match-end 1)
                  'type 'zk-link)))
 
@@ -720,21 +721,16 @@ Optionally call a custom function by setting the variable
       (error "No zk-link at point"))))
 
 (defun zk--links-in-note-list ()
-  "Return list of links in note with ID."
-  (let ((id-list)
-        (zk-ids (zk--id-list)))
+  "Return list of zk files that are linked from the current buffer."
+  (let (id-list)
     (save-buffer)
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward zk-link-regexp nil t)
-        (if (member (match-string-no-properties 1) zk-ids)
-            (push (match-string-no-properties 1) id-list))))
-    (cond ((null id-list)
-           (error "No zk-links in note"))
-          ((eq 1 (length id-list))
-           (list (zk--parse-id 'file-path id-list)))
-          (t
-           (zk--parse-id 'file-path (delete-dups id-list))))))
+      (while (re-search-forward (zk-link-regexp) nil t)
+        (push (match-string-no-properties 1) id-list)))
+    (if (null id-list)
+        (message "No zk-links in note")
+      (zk--parse-ids 'file-path (delete-dups id-list)))))
 
 ;;;###autoload
 (defun zk-links-in-note ()
@@ -924,7 +920,7 @@ Select TAG, with completion, from list of all tags in zk notes."
   (let* ((files (shell-command-to-string (concat
                                           "grep -ohir -e "
                                           (shell-quote-argument
-                                           zk-link-regexp)
+                                           (zk-link-regexp))
                                           " "
                                           zk-directory " 2>/dev/null")))
          (list (split-string files "\n" t))

--- a/zk.el
+++ b/zk.el
@@ -187,7 +187,7 @@ replaced by a note's ID."
 (defmacro zk-link-regexp ()
   "Returns the regexp matching a zk link based on `zk-link-format' and
 `zk-id-regexp'."
-  `(format (regexp-quote ,zk-link-format) ,zk-id-regexp))
+  '(format (regexp-quote zk-link-format) zk-id-regexp))
 
 (defcustom zk-link-and-title t
   "Should `zk-insert-link' insert both link and title?


### PR DESCRIPTION
This way zk-link-regexp is generated at run-time, so it always reflects user
changes to zk-link-format and zk-id-regexp.