### PR TITLE
Fix handling of zk-index-desktop-directory not being set

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -396,8 +396,8 @@ Optionally refresh with FILES, using FORMAT-FN, SORT-FN, BUF-NAME."
 (defun zk-index-button-display-action (file buffer)
   "Function to display FILE or BUFFER on button press in Index and Desktop."
   (if (and zk-index-desktop-directory
-	   (file-in-directory-p zk-index-desktop-directory
-				default-directory))
+	       (file-in-directory-p zk-index-desktop-directory
+				                default-directory))
       ;; display action for ZK-Desktop
       (progn
         (if (one-window-p)

--- a/zk-index.el
+++ b/zk-index.el
@@ -395,8 +395,9 @@ Optionally refresh with FILES, using FORMAT-FN, SORT-FN, BUF-NAME."
 
 (defun zk-index-button-display-action (file buffer)
   "Function to display FILE or BUFFER on button press in Index and Desktop."
-  (if (file-in-directory-p zk-index-desktop-directory
-                           default-directory)
+  (if (and zk-index-desktop-directory
+	   (file-in-directory-p zk-index-desktop-directory
+				default-directory))
       ;; display action for ZK-Desktop
       (progn
         (if (one-window-p)
@@ -801,6 +802,8 @@ If `zk-index-auto-scroll' is non-nil, show note in other window."
 (defun zk-index-desktop-select ()
   "Select a ZK-Desktop to work with."
   (interactive)
+  (unless zk-index-desktop-directory
+    (error "Please set `zk-index-desktop-directory' first"))
   (let* ((last-command last-command)
          (desktop
           (completing-read "Select or Create ZK-Desktop: "
@@ -923,7 +926,7 @@ Also works on FILES or group of files in minibuffer, and on zk-id
 at point."
   (interactive)
   (unless zk-index-desktop-directory
-    (error "Please set 'zk-index-desktop-directory'"))
+    (error "Please set `zk-index-desktop-directory' first"))
   (let ((inhibit-read-only t)
         (buffer) (items))
     (cond ((eq 1 (length files))


### PR DESCRIPTION
This is especially important in `zk-index-button-display-action`, since the function is called for both zk-index and zk-desktop buttons, so opening any link gives an error from `file-in-directory-p`.