### PR TITLE
Fix zk-index--current-id-list mis-matching zk-id-regexp

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -576,12 +576,12 @@ with query term STRING."
 (defun zk-index--current-id-list (buf-name)
   "Return list of IDs for index in BUF-NAME, as filepaths."
   (let (ids)
-    (with-current-buffer (or buf-name
-                             zk-index-buffer-name)
-      (save-excursion
+    (save-excursion
+      (with-current-buffer (or buf-name
+                               zk-index-buffer-name)
         (goto-char (point-min))
         (save-match-data
-          (while (re-search-forward zk-id-regexp nil t)
+          (while (re-search-forward (concat "^" zk-id-regexp) nil t)
             (push (match-string-no-properties 0) ids)))
         ids))))
 


### PR DESCRIPTION
This way, the function only matches `zk-id-regexp` at the beginning of each line rather than anywhere. While with the default `zk-id-regexp` it is unlikely that a file title will include something resembling the id, once customized there is a potential for a difficult to trace bug.

For example, my `zk-id-regexp` is much shorter, `"[a-z]-[0-9]\\{4\\}"`, so `zk-index--curent-id-list` mis-matched against title containing "since mid-2000s," which introduced a nil into the ID list that then impacted sorting by size since `#'<` signaled an error comparing a number against nil.