### PR TITLE
Feature: Add zk-subdirectory-function for determining subdirectory to put new notes in

### DIFF
--- a/zk.el
+++ b/zk.el
@@ -558,6 +558,20 @@ Adds `zk-make-link-buttons' to `find-file-hook.'"
 
 ;;; Note Functions
 
+(defun zk--note-file-path (id title)
+  "Generate file-path for new note.
+Takes an ID and TITLE and returns a full file path, based on values of
+`zk-directory', `zk-file-name-separator', and
+`zk-file-name-separator'."
+  (format "%s/%s%s%s.%s"
+          zk-directory
+          id
+          zk-file-name-separator
+          ;; Only replace spaces with inside the title, since `zk-directory'
+          ;; might contain valid spaces.
+          (replace-regexp-in-string " " zk-file-name-separator title)
+          zk-file-extension))
+
 ;;;###autoload
 (defun zk-new-note (&optional title)
   "Create a new note, insert link at point of creation.
@@ -587,15 +601,7 @@ Optional TITLE argument."
                    (buffer-substring
                     (point)
                     (point-max)))))
-         (file-name (replace-regexp-in-string " "
-                                              zk-file-name-separator
-                                              (concat
-                                               (format "%s/%s%s%s.%s"
-                                                       zk-directory
-                                                       new-id
-                                                       zk-file-name-separator
-                                                       title
-                                                       zk-file-extension)))))
+         (file-name (zk--note-file-path new-id title)))
     (unless orig-id
       (setq orig-id zk-default-backlink))
     (when (use-region-p)
@@ -659,15 +665,7 @@ title."
       (re-search-forward " ")
       (delete-region (point) (line-end-position))
       (insert new-title))
-    (let ((new-file (concat
-                     zk-directory "/"
-                     id
-                     zk-file-name-separator
-                     (replace-regexp-in-string
-                      " "
-                      zk-file-name-separator
-                      new-title)
-                     "." zk-file-extension)))
+    (let ((new-file (zk--note-file-path id new-title)))
       (rename-file buffer-file-name new-file t)
       (set-visited-file-name new-file t t)
       (save-buffer))))

--- a/zk.el
+++ b/zk.el
@@ -83,13 +83,20 @@
 
 ;; Borrowed from Deft by Jason R. Blevins <jblevins@xbeta.org>
 (defcustom zk-directory-recursive nil
-  "Recursively search for files in subdirectories of `zk-directory'."
+  "Recursively search for files in subdirectories of `zk-directory'.
+If you set this, also consider setting `zk-subdirectory-function'."
   :type 'boolean)
 
 (defcustom zk-directory-recursive-ignore-dir-regexp
   "\\(?:\\.\\|\\.\\.\\)$"
   "Regexp for subdirs to be ignored when ‘zk-directory-recursive’ is non-nil."
   :type 'string)
+
+(defcustom zk-subdirectory-function nil
+  "A function that given a zk ID, returns a relative subdirectory in
+`zk-directory' where the note should be stored. The default is to save
+all zk files directly in `zk-directory'."
+  :type 'function)
 
 (defcustom zk-file-extension nil
   "The extension for zk files."
@@ -560,18 +567,20 @@ Adds `zk-make-link-buttons' to `find-file-hook.'"
 
 (defun zk--note-file-path (id title)
   "Generate full file-path for note with given ID and TITLE based on
-`zk-directory', `zk-file-name-separator', and `zk-file-extension'."
+`zk-directory', `zk-subdirectory-function', `zk-file-name-separator',
+and `zk-file-extension'."
   (let ((base-name
          (format "%s%s%s.%s"
                  id
                  zk-file-name-separator
                  title
                  zk-file-extension)))
-     (concat (file-name-as-directory zk-directory)
-             (replace-regexp-in-string " "
-                                       zk-file-name-separator
-                                       base-name))))
-
+    (concat (file-name-as-directory zk-directory)
+            (when (functionp zk-subdirectory-function)
+              (file-name-as-directory (funcall zk-subdirectory-function id)))
+            (replace-regexp-in-string " "
+                                      zk-file-name-separator
+                                      base-name))))
 
 ;;;###autoload
 (defun zk-new-note (&optional title)

--- a/zk.el
+++ b/zk.el
@@ -93,9 +93,10 @@ If you set this, also consider setting `zk-subdirectory-function'."
   :type 'string)
 
 (defcustom zk-subdirectory-function nil
-  "A function that given a zk ID, returns a relative subdirectory in
-`zk-directory' where the note should be stored. The default is to save
-all zk files directly in `zk-directory'."
+  "Function that returns a subdirectory of `zk-directory'.
+Used when `zk-directory-recursive' is non-nil to create new notes
+in the desired subdirectory. When nil, new notes are created in
+`zk-directory'."
   :type 'function)
 
 (defcustom zk-file-extension nil
@@ -566,15 +567,12 @@ Adds `zk-make-link-buttons' to `find-file-hook.'"
 ;;; Note Functions
 
 (defun zk--note-file-path (id title)
-  "Generate full file-path for note with given ID and TITLE based on
-`zk-directory', `zk-subdirectory-function', `zk-file-name-separator',
-and `zk-file-extension'."
-  (let ((base-name
-         (format "%s%s%s.%s"
-                 id
-                 zk-file-name-separator
-                 title
-                 zk-file-extension)))
+  "Generate full file-path for note with given ID and TITLE."
+  (let ((base-name (format "%s%s%s.%s"
+                           id
+                           zk-file-name-separator
+                           title
+                           zk-file-extension)))
     (concat (file-name-as-directory zk-directory)
             (when (functionp zk-subdirectory-function)
               (file-name-as-directory (funcall zk-subdirectory-function id)))

--- a/zk.el
+++ b/zk.el
@@ -559,18 +559,19 @@ Adds `zk-make-link-buttons' to `find-file-hook.'"
 ;;; Note Functions
 
 (defun zk--note-file-path (id title)
-  "Generate file-path for new note.
-Takes an ID and TITLE and returns a full file path, based on values of
-`zk-directory', `zk-file-name-separator', and
-`zk-file-name-separator'."
-  (format "%s/%s%s%s.%s"
-          zk-directory
-          id
-          zk-file-name-separator
-          ;; Only replace spaces with inside the title, since `zk-directory'
-          ;; might contain valid spaces.
-          (replace-regexp-in-string " " zk-file-name-separator title)
-          zk-file-extension))
+  "Generate full file-path for note with given ID and TITLE based on
+`zk-directory', `zk-file-name-separator', and `zk-file-extension'."
+  (let ((base-name
+         (format "%s%s%s.%s"
+                 id
+                 zk-file-name-separator
+                 title
+                 zk-file-extension)))
+     (concat (file-name-as-directory zk-directory)
+             (replace-regexp-in-string " "
+                                       zk-file-name-separator
+                                       base-name))))
+
 
 ;;;###autoload
 (defun zk-new-note (&optional title)


### PR DESCRIPTION
Customizing this variable allows note creation and renaming commands to put notes in subdirectories under `zk-directory` for when `zk-directory-recursive' is set. One easy such function to have subdirectories for each year might be set like this:

``` emacs-lisp
(custom-set-variables '(zk-subdirectory-function (lambda (id) (seq-subseq id 0 4))))
```

I also extracted file path generating function `zk--note-file-path' from `zk-new-note' and `zk-rename-note', where this functionality was duplicated, so more difficult to change.