### PR TITLE
Optimize (eq 1 (length X)) and add syntactic sugar function zk--singleton-p

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -338,7 +338,7 @@ Optionally refresh with FILES, using FORMAT-FN, SORT-FN, BUF-NAME."
   "Sort FILES, with option FORMAT-FN and SORT-FN."
   (let* ((sort-fn (or sort-fn
                       'zk-index--sort-modified))
-         (files (if (eq 1 (length files))
+         (files (if (zk--singleton-p files)
                     files
                   (nreverse (funcall sort-fn files)))))
     (funcall #'zk-index--format files format-fn)))
@@ -937,8 +937,7 @@ at point."
     (error "Please set `zk-index-desktop-directory' first"))
   (let ((inhibit-read-only t)
         (buffer) (items))
-    (cond ((and files
-                (null (cdr files)))     ; 1 element in files
+    (cond ((zk--singleton-p files)
            (unless
                (ignore-errors
                  (setq items (car (funcall zk-index-format-function files))))

--- a/zk-index.el
+++ b/zk-index.el
@@ -937,22 +937,22 @@ at point."
     (error "Please set `zk-index-desktop-directory' first"))
   (let ((inhibit-read-only t)
         (buffer) (items))
-    (cond ((eq 1 (length files))
+    (cond ((and files
+                (null (cdr files)))     ; 1 element in files
            (unless
                (ignore-errors
                  (setq items (car (funcall zk-index-format-function files))))
              (setq items
-                   (car
-                    (funcall
-                     zk-index-format-function
-                     (list (zk--parse-id 'file-path files)))))))
-          ((and files
-                (< 1 (length files)))
+               (car
+                (funcall
+                 zk-index-format-function
+                 (list (zk--parse-id 'file-path files)))))))
+          (files                        ; > 1 elements in files
            (setq items
-                 (mapconcat
-                  #'identity
-                  (funcall zk-index-format-function files) "\n")))
-          ((eq major-mode 'zk-index-mode)
+             (mapconcat
+                 #'identity
+               (funcall zk-index-format-function files) "\n")))
+          ((eq major-mode 'zk-index-mode) ; no elements in files
            (setq items (if (use-region-p)
                            (buffer-substring
                             (save-excursion
@@ -964,12 +964,14 @@ at point."
                          (buffer-substring
                           (line-beginning-position)
                           (line-end-position)))))
-          ((zk-file-p)
+          ((zk-file-p)                  ; no elements in files
            (setq items
-                 (car
-                  (funcall
-                   zk-index-format-function
-                   (list (zk--parse-id 'file-path (zk--current-id))))))))
+             (car
+              (funcall
+               zk-index-format-function
+               (list (zk--parse-id 'file-path (zk--current-id)))))))
+          (t
+           (user-error "Don't know how to send this to desktop")))
     (if (and zk-index-desktop-current
              (buffer-live-p (get-buffer zk-index-desktop-current)))
         (setq buffer zk-index-desktop-current)

--- a/zk.el
+++ b/zk.el
@@ -487,7 +487,8 @@ in an internal loop."
                          (lambda (x)
                            (cadr (assoc x zk-alist)))
                          ids)))))))
-    (if (eq 1 (length return))
+    (if (and (listp return)
+             (null (cdr return)))
         (car return)
       return)))
 


### PR DESCRIPTION
Replacing the `(eq 1 (length X))` test with `(null (cdr X))` avoids having to "walk" the length of the X list each time. With a list of 2243 files, difference adds up to 0.43 seconds for 100,000 repetitions and to 5.55 seconds for 1,000,000 repetitions. Not a big difference, but still.

Since it is good to make sure that X is actually a list before calling `(cdr X)`, which would throw an error, I've added `zk--singleton-p` inline function as syntactic sugar. Singleton in mathematics is a set of one element, so seems fitting, though perhaps `zk--one-element-p` or `zk--single-element-p` might be more readable. What do you think?
