### PR TITLE
Feature: add options for extended and inverted grep

### DIFF
--- a/zk.el
+++ b/zk.el
@@ -382,18 +382,22 @@ file-paths."
              (buffer-file-name x)))
          (buffer-list))))
 
-(defun zk--grep-file-list (str)
-  "Return a list of files containing regexp STR."
-  (let* ((files (shell-command-to-string (concat
-                                          "grep -lir --include \\*."
-                                          zk-file-extension
-                                          " -e "
-                                          (shell-quote-argument
-                                           str)
-                                          " "
-                                          zk-directory
-                                          " 2>/dev/null"))))
-    (split-string files "\n" t)))
+(defun zk--grep-file-list (str &optional extended invert)
+  "Return a list of files containing regexp STR.
+If EXTENDED is non-nil, use egrep. If INVERT is non-nil,
+return list of files not matching the regexp."
+  (split-string
+   (shell-command-to-string
+    (concat (if extended "egrep" "grep")
+            (if invert " -L" " -l")
+            " -ir --include \\*."
+            zk-file-extension
+            " -e "
+            (shell-quote-argument str)
+            " "
+            zk-directory
+            " 2>/dev/null"))
+   "\n" t))
 
 (defun zk--grep-id-list (str)
   "Return a list of IDs for files containing STR."

--- a/zk.el
+++ b/zk.el
@@ -389,13 +389,12 @@ return list of files not matching the regexp."
   (split-string
    (shell-command-to-string
     (concat (if extended "egrep" "grep")
-            (if invert " -L" " -l")
-            " -ir --include \\*."
-            zk-file-extension
-            " -e "
-            (shell-quote-argument str)
-            " "
-            zk-directory
+            (if invert " --lines-without-match" " --lines-with-matches")
+            " --recursive"
+            " --ignore-case"
+            " --include \\*." zk-file-extension
+            " --regexp=" (shell-quote-argument str)
+            " " zk-directory
             " 2>/dev/null"))
    "\n" t))
 


### PR DESCRIPTION
This has no effect on existing code, but allows easier creation of additional features, such as searching for zk files that /do not/ contain a certain phrase. Extended grep syntax is easier to write programmatically since don't need to do as much backslashing.

I also replaced the grep invocation in `zk--grep-file-list` with the spelled-out arguments, making it easier to tell at a glance what particular arguments do.