### PR TITLE
Fix a typo in zk--grep-file-list's grep command

### DIFF
--- a/zk.el
+++ b/zk.el
@@ -389,7 +389,7 @@ return list of files not matching the regexp."
   (split-string
    (shell-command-to-string
     (concat (if extended "egrep" "grep")
-            (if invert " --lines-without-match" " --lines-with-matches")
+            (if invert " --files-without-match" " --files-with-matches")
             " --recursive"
             " --ignore-case"
             " --include \\*." zk-file-extension


### PR DESCRIPTION
Sorry, I apparently was thinking of something else while typing. I did more rigorous testing with ERT this time to make sure the function works as expected.