### PR TITLE
Refactor zk-index and zk-index-refresh

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -1002,11 +1002,9 @@ at point."
   "Switch to ZK-Index buffer."
   (interactive)
   (let ((buffer zk-index-buffer-name))
-    (unless (get-buffer buffer)
-      (progn
-        (generate-new-buffer buffer)
-        (zk-index-refresh)))
-    (switch-to-buffer buffer)))
+    (if (get-buffer buffer)
+        (switch-to-buffer buffer)
+      (zk-index))))
 
 ;;;###autoload
 (defun zk-index-switch-to-desktop ()

--- a/zk-index.el
+++ b/zk-index.el
@@ -63,11 +63,11 @@
 
 (defcustom zk-index-format "%t [[%i]]"
   "Default format for candidates in the index."
-    :type 'string)
+  :type 'string)
 
 (defcustom zk-index-prefix "-> "
   "String to prepend to note names in ZK-Index."
-    :type 'string)
+  :type 'string)
 
 (defcustom zk-index-auto-scroll t
   "Enable automatically showing note at point in ZK-Index."
@@ -380,7 +380,7 @@ FORMAT-FN, SORT-FN, AND BUF-NAME should always be provided."
               (re-search-forward id)
               (replace-match
                (propertize id 'invisible t)))
-              (goto-char (match-end 0))))))))
+            (goto-char (match-end 0))))))))
 
 ;;;; Utilities
 
@@ -411,8 +411,7 @@ FORMAT-FN, SORT-FN, AND BUF-NAME should always be provided."
   "Action taken when `zk-index' button is pressed."
   (let* ((id (zk-index--button-at-point-p))
          (file (zk--parse-id 'file-path id))
-         (buffer
-          (find-file-noselect file)))
+         (buffer (find-file-noselect file)))
     (funcall zk-index-button-display-function file buffer)))
 
 (defun zk-index-help-echo (win _obj pos)
@@ -542,11 +541,11 @@ with query term STRING."
                                 (split-string (symbol-name (car query)) "-")))
                               ": \""
                               (cdr query))))
-                         ;; Put the last query type at the end
-                         (sort (remq nil formatted)
-                               (lambda (a _b)
-                                 (not (equal (car a) query-command))))
-                         "\" | ")
+                ;; Put the last query type at the end
+                (sort (remq nil formatted)
+                      (lambda (a _b)
+                        (not (equal (car a) query-command))))
+                "\" | ")
               "\"]"))))
 
 (defun zk-index--set-mode-line (string)
@@ -674,8 +673,8 @@ with query term STRING."
   (interactive)
   (beginning-of-line)
   (let* ((id (zk-index--button-at-point-p))
-        (kill (unless (get-file-buffer (zk--parse-id 'file-path id))
-                t)))
+         (kill (unless (get-file-buffer (zk--parse-id 'file-path id))
+                 t)))
     (push-button nil t)
     (setq-local zk-index-view--kill kill)
     (zk-index-view-mode)))
@@ -992,8 +991,8 @@ at point."
 (defun zk-index-desktop-add-toggle ()
   "Set `zk-index-desktop-add-pos' interactively."
   (interactive)
-   (let ((choice (read-char "Choice: \[a\]ppend; \[p\]repend; at-\[P\]oint")))
-     (pcase choice
+  (let ((choice (read-char "Choice: \[a\]ppend; \[p\]repend; at-\[P\]oint")))
+    (pcase choice
       ('?a (setq zk-index-desktop-add-pos 'append))
       ('?p (setq zk-index-desktop-add-pos 'prepend))
       ('?P (setq zk-index-desktop-add-pos 'at-point)))))
@@ -1125,16 +1124,16 @@ With prefix-argument, raise ZK-Desktop in other frame."
                 (zk-index--button-at-point-p (region-beginning))
                 (not (zk-index--button-at-point-p (region-end))))
            (kill-region (save-excursion
-                            (goto-char (region-beginning))
-                            (line-beginning-position))
-                          (region-end)))
+                          (goto-char (region-beginning))
+                          (line-beginning-position))
+                        (region-end)))
           ((and (use-region-p)
                 (not (zk-index--button-at-point-p (region-beginning)))
                 (zk-index--button-at-point-p (region-end)))
            (kill-region (region-beginning)
-                          (save-excursion
-                            (goto-char (region-end))
-                            (line-end-position))))
+                        (save-excursion
+                          (goto-char (region-end))
+                          (line-end-position))))
           ((and (use-region-p)
                 (zk-index--button-at-point-p (region-beginning))
                 (zk-index--button-at-point-p (region-end)))
@@ -1147,7 +1146,7 @@ With prefix-argument, raise ZK-Desktop in other frame."
               (line-end-position))))
           ((use-region-p)
            (kill-region (region-beginning)
-                          (region-end))))))
+                        (region-end))))))
 
 (defun zk-index-desktop-yank ()
   "Wrapper around `yank' for `zk-index-desktop-mode'."

--- a/zk-index.el
+++ b/zk-index.el
@@ -280,30 +280,21 @@ FILES must be a list of filepaths. If nil, all files in
 (defun zk-index (&optional files format-fn sort-fn buf-name)
   "Open ZK-Index, with optional FILES, FORMAT-FN, SORT-FN, BUF-NAME."
   (interactive)
-  (setq zk-index-last-format-function format-fn)
-  (setq zk-index-last-sort-function sort-fn)
-  (let ((inhibit-message nil)
-        (inhibit-read-only t)
-        (buf-name (or buf-name
-                      zk-index-buffer-name))
-        (list (or files
-                  (zk--directory-files t))))
-    (if (not (get-buffer buf-name))
-        (progn
-          (when zk-default-backlink
-            (unless (zk-file-p)
-              (zk-find-file-by-id zk-default-backlink)))
-          (generate-new-buffer buf-name)
-          (with-current-buffer buf-name
-            (setq default-directory (expand-file-name zk-directory))
-            (zk-index-mode)
-            (zk-index--sort list format-fn sort-fn)
-            (setq truncate-lines t)
-            (goto-char (point-min)))
-          (pop-to-buffer buf-name
-                         '(display-buffer-at-bottom)))
-      (when files
-        (zk-index-refresh files format-fn sort-fn buf-name))
+  (let ((inhibit-read-only t)
+        (buf-name (or buf-name zk-index-buffer-name))
+        (files (or files (zk--directory-files t))))
+    ;; On the first run, open `zk-default-backlink' if it's set
+    ;; and we are not already editing a zk file.
+    (when (and zk-default-backlink
+               (not (get-buffer buf-name))
+               (not (zk-file-p (buffer-file-name))))
+      (zk-find-file-by-id zk-default-backlink))
+    (if (not files)
+        (message "There are no zk files to display")
+      (with-current-buffer (get-buffer-create buf-name)
+        (setq default-directory (expand-file-name zk-directory))
+        (zk-index-mode))
+      (zk-index-refresh files format-fn sort-fn buf-name)
       (pop-to-buffer buf-name
                      '(display-buffer-at-bottom)))))
 

--- a/zk-index.el
+++ b/zk-index.el
@@ -507,8 +507,9 @@ items listed first.")
         (files (zk-index--current-file-list)))
     (unless (stringp files)
       (zk-index-refresh files
-                        nil
-                        zk-index-last-sort-function)
+                        zk-index-format-function
+                        zk-index-last-sort-function
+                        zk-index-buffer-name)
       (setq mode-name mode))))
 
 (defun zk-index-query-mode-line (query-command string)

--- a/zk.el
+++ b/zk.el
@@ -213,9 +213,10 @@ will be replaced by its ID."
   :type 'string)
 
 (defcustom zk-default-backlink nil
-  "When non-nil, should be a single zk ID.
+  "Default backlink for new notes when there is no immediate parent note.
 See `zk-new-note' for details."
-  :type 'string)
+  :type '(choice (string :tag "zk ID")
+                 (const :tag "None" nil)))
 
 (defcustom zk-current-notes-function nil
   "User-defined function for listing currently open notes.


### PR DESCRIPTION
This is just a bit of a cleanup of some duplicate functionality between `zk-index`, `zk-index-refresh`, and `zk-switch-to-index`.

The biggest (and breaking) change is the split of `zk-index-refresh` into user command `zk-index-refresh` that takes no arguments and internal function `zk-index--refresh` that does. This better encapsulates functionality, so that the internal function `zk-index--refresh` doesn't need to fill in missing parameters when called as a user command. Both the function and the command are now more modular, doing just one thing, so it will be easier to make changes if need be without having to worry about affecting unrelated things (user experience vs. internal function).

I haven't yet gotten to set up zk-luhmann, but I can see there is one call to `zk-index-refresh` on line 278 that would need to be updated to `zk-index--refresh`.