### PR TITLE
Improve performance for zk-completion-at-point

### DIFF
--- a/zk.el
+++ b/zk.el
@@ -827,7 +827,8 @@ FILES must be a list of filepaths. If nil, all files in
 When added to `completion-at-point-functions', typing two
 brackets \"[[\" initiates completion."
   (let ((case-fold-search t)
-        (origin (point)))
+        (origin (point))
+        (candidates (zk--format-candidates)))
     (save-excursion
       (when (and (re-search-backward "\\[\\["
                                      (line-beginning-position)
@@ -838,7 +839,7 @@ brackets \"[[\" initiates completion."
               origin
               (completion-table-dynamic
                (lambda (_)
-                 (zk--format-candidates)))
+                 candidates))
               :exit-function
               (lambda (str _status)
                 (delete-char (- -2 (length str)))


### PR DESCRIPTION
Using a lexical closure allows capturing the pre-formatted completion table rather than having the function re-calculate the same list from scratch at every change in input.

I tested this with ERT (Emacs Lisp Regression Tests) and ELP (Emacs Lisp Profiler). For 50 simulated completions, runtime went from around 50 seconds (first screenshot, "main") to less than 25 seconds (second screenshot):

[![2022-10-28-at-22-07-50.jpg](https://i.postimg.cc/Nfr7f6Tk/2022-10-28-at-22-07-50.jpg)](https://postimg.cc/HVd7676r)

[![2022-10-28-at-22-26-21.png](https://i.postimg.cc/cJRywtnp/2022-10-28-at-22-26-21.png)](https://postimg.cc/nshPtzT2)