### PR TITLE
Extract direct references to format-spec into zk--format-spec

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -244,9 +244,7 @@ Adds zk-id as an Embark target, and adds `zk-id-map' and
 (defun zk-index--format-candidates (&optional files format)
   "Return a list of FILES as formatted candidates, following FORMAT.
 
-FORMAT must be a `format-spec' template, wherein `%i' is replaced
-by the ID and `%t' by the title. It can be a string, such as \"%t
-[[%i]]\", or a variable whose value is a string. If nil,
+See `zk--format-spec' for details about FORMAT. If nil,
 `zk-completion-at-point-format' will be used by default.
 
 FILES must be a list of filepaths. If nil, all files in
@@ -259,8 +257,7 @@ FILES must be a list of filepaths. If nil, all files in
                    (zk--directory-files)))
          (output))
     (dolist (file list)
-      (progn
-        (string-match (zk-file-name-regexp) file)
+      (when (string-match (zk-file-name-regexp) file)
         (let ((id (if zk-index-invisible-ids
                       (propertize (match-string 1 file) 'invisible t)
                     (match-string 1 file)))
@@ -268,10 +265,7 @@ FILES must be a list of filepaths. If nil, all files in
                       zk-file-name-separator
                       " "
                       (match-string 2 file))))
-          (when id
-            (push (format-spec format
-                               `((?i . ,id)(?t . ,title)))
-                  output)))))
+          (push (zk--format-spec format id title) output))))
     output))
 
 ;;; Main Stack

--- a/zk-index.el
+++ b/zk-index.el
@@ -244,7 +244,7 @@ Adds zk-id as an Embark target, and adds `zk-id-map' and
 (defun zk-index--format-candidates (&optional files format)
   "Return a list of FILES as formatted candidates, following FORMAT.
 
-See `zk--format-spec' for details about FORMAT. If nil,
+See `zk--format' for details about FORMAT. If nil,
 `zk-completion-at-point-format' will be used by default.
 
 FILES must be a list of filepaths. If nil, all files in
@@ -265,7 +265,7 @@ FILES must be a list of filepaths. If nil, all files in
                       zk-file-name-separator
                       " "
                       (match-string 2 file))))
-          (push (zk--format-spec format id title) output))))
+          (push (zk--format format id title) output))))
     output))
 
 ;;; Main Stack

--- a/zk.el
+++ b/zk.el
@@ -758,7 +758,7 @@ Optionally call a custom function by setting the variable
 
 ;;; Insert Link
 
-(defun zk--format-spec (format id title)
+(defun zk--format (format id title)
   "Format ID and TITLE based on the `format-spec' FORMAT.
 The sequence `%t' will be replaced by the TITLE and `%i' will be
 replaced by ID."
@@ -794,7 +794,7 @@ for additional configurations."
 
 (defun zk--insert-link-and-title (id title)
   "Insert zk ID and TITLE according to `zk-link-and-title-format'."
-  (insert (zk--format-spec zk-link-and-title-format id title))
+  (insert (zk--format zk-link-and-title-format id title))
   (when zk-enable-link-buttons
     (zk-make-button-before-point)))
 
@@ -803,7 +803,7 @@ for additional configurations."
 (defun zk--format-candidates (&optional files format)
   "Return a list of FILES as formatted candidates, following FORMAT.
 
-See `zk--format-spec' for details about FORMAT. If nil,
+See `zk--format' for details about FORMAT. If nil,
 `zk-completion-at-point-format' will be used by default.
 
 FILES must be a list of filepaths. If nil, all files in `zk-directory'
@@ -818,7 +818,7 @@ will be returned as formatted candidates."
         (let ((id (match-string 1 file))
               (title (replace-regexp-in-string zk-file-name-separator " "
                                                (match-string 2 file))))
-          (push (zk--format-spec format id title) output))))
+          (push (zk--format format id title) output))))
     output))
 
 (defun zk-completion-at-point ()
@@ -863,7 +863,7 @@ brackets \"[[\" initiates completion."
          (title (zk--parse-id 'title id)))
     (if (null id)
         (error "No valid zk-id")
-      (kill-new (zk--format-spec zk-link-and-title-format id title))
+      (kill-new (zk--format zk-link-and-title-format id title))
       (message "Link and title copied: %s" title))))
 
 

--- a/zk.el
+++ b/zk.el
@@ -172,6 +172,12 @@ Must take a single STRING argument."
 See `zk-current-notes' for details."
   :type 'function)
 
+(defcustom zk-format-function nil
+  "User-defined function for formatting zk file information.
+The function should accept three variables: FORMAT-SPEC, ID, and
+TITLE. See `zk-format' for details."
+  :type 'function)
+
 ;; Format variables
 
 (defcustom zk-link-format "[[%s]]"
@@ -183,15 +189,15 @@ replaced by a note's ID."
 (defcustom zk-link-and-title-format "%t [[%i]]"
   "Format for link and title when inserted to together.
 
-The string `%t' will be replaced by the note's title and `%i'
-will be replaced by its ID."
+By default (when `zk-format-function' is nil), the string `%t' will be
+replaced by the note's title and `%i' will be replaced by its ID."
   :type 'string)
 
 (defcustom zk-completion-at-point-format "[[%i]] %t"
   "Format for completion table used by `zk-completion-at-point'.
 
-The string `%t' will be replaced by the note's title and `%i'
-will be replaced by its ID."
+By default (when `zk-format-function' is nil), the string `%t' will be
+replaced by the note's title and `%i' will be replaced by its ID."
   :type 'string)
 
 ;; Link variables
@@ -768,9 +774,11 @@ Optionally call a custom function by setting the variable
 
 (defun zk--format (format id title)
   "Format ID and TITLE based on the `format-spec' FORMAT.
-The sequence `%t' will be replaced by the TITLE and `%i' will be
-replaced by ID."
-  (format-spec format `((?i . ,id) (?t . ,title))))
+If `zk-format-function' is set, call that function. Otherwise, replace
+the sequence `%t' with the TITLE and `%i' with the ID."
+  (if (functionp zk-format-function)
+      (funcall zk-format-function format id title)
+    (format-spec format `((?i . ,id) (?t . ,title)))))
 
 ;;;###autoload
 (defun zk-insert-link (id &optional title)

--- a/zk.el
+++ b/zk.el
@@ -77,6 +77,8 @@
   :group 'files
   :prefix "zk-")
 
+;; Fundamental variables
+
 (defcustom zk-directory nil
   "Main zk directory."
   :type 'string)
@@ -112,12 +114,6 @@ for example, the file-name will be in the form
 rendered with spaces."
   :type 'string)
 
-(defcustom zk-enable-link-buttons t
-  "When non-nil, valid zk-id links will be clickable buttons.
-Allows `zk-make-link-buttons' to be added to `find-file-hook', so
-buttons will be automatically created when a note is opened."
-  :type 'boolean)
-
 (defcustom zk-id-time-string-format "%Y%m%d%H%M"
   "Format for new zk IDs.
 For supported options, please consult `format-time-string'.
@@ -136,6 +132,8 @@ Set it so that it matches strings generated with
   "The regular expression used to search for tags."
   :type 'regexp)
 
+;; Function variables
+
 (defcustom zk-new-note-header-function #'zk-new-note-header
   "Function called by `zk-new-note' to insert header in a new note.
 A user-defined function should use `insert' to insert a string or
@@ -143,22 +141,6 @@ strings. The arguments NEW-ID, TITLE, and ORIG-ID can be used to
 those corresponding values from `zk-new-note' available for
 insertion. See `zk-new-note-header' for an example."
   :type 'function)
-
-(defcustom zk-new-note-link-insert 'ask
-  "Should `zk-new-note' insert link to new note at point?
-
-Options:
-1. t - Always insert a link
-2. `zk - Insert link only inside an existing note
-3. `ask - Ask user, yes or no
-4. nil - Never insert a link
-
-Calling `zk-new-note' with a prefix-argument inserts a link
-regardless of how `zk-new-note-link-insert' is set."
-  :type '(choice (const :tag "Always" t)
-                 (const :tag "Ask" ask)
-                 (const :tag "Only in zk notes" zk)
-                 (const :tag "Never" nil)))
 
 (defcustom zk-select-file-function #'zk--select-file
   "Function for performing completing read.
@@ -185,11 +167,50 @@ Must take a single STRING argument."
  'zk-tag-search-function' should be used instead"
                         "0.5")
 
+(defcustom zk-current-notes-function nil
+  "User-defined function for listing currently open notes.
+See `zk-current-notes' for details."
+  :type 'function)
+
+;; Format variables
+
 (defcustom zk-link-format "[[%s]]"
   "Format for inserted links.
 Used in conjunction with `format', the string `%s' will be
 replaced by a note's ID."
   :type 'string)
+
+(defcustom zk-link-and-title-format "%t [[%i]]"
+  "Format for link and title when inserted to together.
+
+The string `%t' will be replaced by the note's title and `%i'
+will be replaced by its ID."
+  :type 'string)
+
+(defcustom zk-completion-at-point-format "[[%i]] %t"
+  "Format for completion table used by `zk-completion-at-point'.
+
+The string `%t' will be replaced by the note's title and `%i'
+will be replaced by its ID."
+  :type 'string)
+
+;; Link variables
+
+(defcustom zk-new-note-link-insert 'ask
+  "Should `zk-new-note' insert link to new note at point?
+
+Options:
+1. t - Always insert a link
+2. `zk - Insert link only inside an existing note
+3. `ask - Ask user, yes or no
+4. nil - Never insert a link
+
+Calling `zk-new-note' with a prefix-argument inserts a link
+regardless of how `zk-new-note-link-insert' is set."
+  :type '(choice (const :tag "Always" t)
+                 (const :tag "Ask" ask)
+                 (const :tag "Only in zk notes" zk)
+                 (const :tag "Never" nil)))
 
 (defcustom zk-link-and-title t
   "Should `zk-insert-link' insert both link and title?
@@ -205,28 +226,15 @@ by setting the variable `zk-link-and-title-format'."
                  (const :tag "Ask" ask)
                  (const :tag "Never" nil)))
 
-(defcustom zk-link-and-title-format "%t [[%i]]"
-  "Format for link and title when inserted to together.
-
-The string `%t' will be replaced by the note's title and `%i'
-will be replaced by its ID."
-  :type 'string)
+(defcustom zk-enable-link-buttons t
+  "When non-nil, valid zk-id links will be clickable buttons.
+Allows `zk-make-link-buttons' to be added to `find-file-hook', so
+buttons will be automatically created when a note is opened."
+  :type 'boolean)
 
 (defcustom zk-default-backlink nil
   "When non-nil, should be a single zk ID.
 See `zk-new-note' for details."
-  :type 'string)
-
-(defcustom zk-current-notes-function nil
-  "User-defined function for listing currently open notes.
-See `zk-current-notes' for details."
-  :type 'function)
-
-(defcustom zk-completion-at-point-format "[[%i]] %t"
-  "Format for completion table used by `zk-completion-at-point'.
-
-The string `%t' will be replaced by the note's title and `%i'
-will be replaced by its ID."
   :type 'string)
 
 (defvar zk-file-history nil)


### PR DESCRIPTION
There are several identical calls to` format-spec`, so making changes or customizing the way things are formatted (beyond the various `-format` variables) is difficult. Having one function that is always used for formatting `id` and `title` makes it possible to customize the behavior by advising the function.

All affected functions have been tested "in the field." I also took the opportunity to slightly refactor some of these factions (like replacing `(progn (string-match ... (when id` with `(when (string-match ...`) without changing functionality at all.