### PR TITLE
Replace zk--current-id with more general function

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -969,7 +969,7 @@ at point."
                  (car
                   (funcall
                    zk-index-format-function
-                   (list (zk--parse-id 'file-path (zk--current-id))))))))
+                   (list buffer-file-name))))))
     (if (and zk-index-desktop-current
              (buffer-live-p (get-buffer zk-index-desktop-current)))
         (setq buffer zk-index-desktop-current)

--- a/zk.el
+++ b/zk.el
@@ -289,6 +289,11 @@ Group 2 is the title."
 The value is based on `zk-link-format' and `zk-id-regexp'."
   (format (regexp-quote zk-link-format) zk-id-regexp))
 
+(defun zk--file-id (file)
+  "Return the ID of the given zk FILE."
+  (when (string-match (zk-file-name-regexp) file)
+    (match-string-no-properties 1 file)))
+
 (defun zk-file-p (&optional file strict)
   "Return t if FILE is a zk-file.
 If FILE is not given, get it from variable `buffer-file-name'.
@@ -300,7 +305,7 @@ otherwise just match against `zk-file-name-regexp'."
                     (t
                      (signal 'wrong-type-argument '(file))))))
     (and file
-         (string-match (zk-file-name-regexp) file)
+         (zk--file-id file)
          (or (not strict)
              (save-match-data
                (file-in-directory-p file zk-directory))))))
@@ -335,11 +340,10 @@ called in an internal loop."
     (member str all-ids)))
 
 (defun zk--current-id ()
-  "Return id of current note."
-  (unless (zk-file-p)
-    (user-error "Not a zk file"))
-  (string-match zk-id-regexp buffer-file-name)
-  (match-string 0 buffer-file-name))
+  "Return the ID of zk note in current buffer."
+  (or (zk--file-id buffer-file-name)
+      (user-error "Not a zk file")))
+(make-obsolete 'zk--current-id 'zk--file-id "0.5")
 
 (defun zk--directory-files (&optional full regexp)
   "Return list of zk-files in `zk-directory'.

--- a/zk.el
+++ b/zk.el
@@ -592,7 +592,7 @@ Optional TITLE argument."
   (interactive)
   (let* ((pref-arg current-prefix-arg)
          (new-id (zk--generate-id))
-         (orig-id (ignore-errors (zk--current-id)))
+         (orig-id (zk--file-id buffer-file-name))
          (text (when (use-region-p)
                  (buffer-substring
                   (region-beginning)
@@ -655,7 +655,7 @@ header title in buffer. If yes, file name changed to header
 title."
   (interactive)
   (read-only-mode -1)
-  (let* ((id (zk--current-id))
+  (let* ((id (zk--file-id buffer-file-name))
          (file-title (zk--parse-id 'title id))
          (header-title (progn
                          (save-excursion
@@ -768,7 +768,8 @@ Optionally call a custom function by setting the variable
 By default, only a link is inserted. With prefix-argument, both
 link and title are inserted. See variable `zk-link-and-title'
 for additional configurations."
-  (interactive (list (zk--parse-file 'id (funcall zk-select-file-function "Insert link: "))))
+  (interactive
+   (list (zk--file-id (funcall zk-select-file-function "Insert link: "))))
   (let* ((pref-arg current-prefix-arg)
          (title (or title
                     (zk--parse-id 'title id))))
@@ -885,7 +886,7 @@ brackets \"[[\" initiates completion."
 (defun zk-backlinks ()
   "Select from list of all notes that link to the current note."
   (interactive)
-  (let* ((id (zk--current-id))
+  (let* ((id (zk--file-id buffer-file-name))
          (files (zk--backlinks-list id)))
     (if files
         (find-file (funcall zk-select-file-function "Backlinks: " files))
@@ -998,7 +999,7 @@ Backlinks and Links-in-Note are grouped separately."
   (interactive)
   (unless (zk-file-p)
     (user-error "Not a zk file"))
-  (let* ((id (ignore-errors (zk--current-id)))
+  (let* ((id (zk--file-id buffer-file-name))
          (backlinks (ignore-errors (zk--backlinks-list id)))
          (links-in-note (ignore-errors (zk--links-in-note-list)))
          (resources))


### PR DESCRIPTION
The function `zk--current-id` is very limited in its use-cases, and its implementation duplicates some functionality (i.e., string-matching against `zk-file-name-regexp`). Adding zk--file-id as a utility function that is like a limited `zk-file-p` that returns a useful value makes it usable in a wider variety of situations.

Having to specify the target is a boon, I believe, since does not result in much longer invocation, but makes it very clear what exactly is "current" without having to look up whether the function uses `buffer-file-name` or `(buffer-file-name)` or something else entirely.

I did some ERT testing and have been using zk and zk-index this way for a few days at least, so everything works as expected.