### PR TITLE
Decouple zk-desktop

### DIFF
--- a/README.org
+++ b/README.org
@@ -430,7 +430,7 @@ interfaces for working with notes in your zk-directory.
 
 For a video demonstration, see: https://youtu.be/7qNT87dphiA
 
-** Setup
+** ZK-Index
 
 This package is available on [[https://melpa.org/#/zk-index][MELPA]]. 
 
@@ -440,12 +440,8 @@ Sample setup with =use-package=:
 (use-package zk-index
   :after zk
   :config
-  (zk-index-setup-embark)
-  :custom
-  (zk-index-desktop-directory zk-directory))
+  (zk-index-setup-embark))
 #+end_src
-
-** ZK-Index
 
 The function =zk-index= pops up a buffer listing of all note titles, each of
 which is a clickable button. Clicking a title will pop the note into the above
@@ -462,7 +458,6 @@ The ZK-Index buffer is in a major mode with a dedicated keymap:
     (define-key map (kbd "o") #'other-window)
     (define-key map (kbd "f") #'zk-index-focus)
     (define-key map (kbd "s") #'zk-index-search)
-    (define-key map (kbd "d") #'zk-index-send-to-desktop)
     (define-key map (kbd "D") #'zk-index-switch-to-desktop)
     (define-key map (kbd "c") #'zk-index-current-notes)
     (define-key map (kbd "i") #'zk-index-refresh)
@@ -531,7 +526,12 @@ directory for saved desktops. A convenient and unobtrusive option is to
 simply use the =zk-directory= itself:
 
 #+begin_src emacs-lisp
-(setq zk-index-desktop-directory zk-directory)
+(use-package zk-desktop
+  :after zk-index
+  :config
+  (zk-desktop-setup-embark)
+  :custom
+  (zk-desktop-directory zk-directory))
 #+end_src
 
 Think of =zk-desktop= as allowing you to achieve something like pulling
@@ -548,7 +548,7 @@ rearranged, grouped, and commented on in-line.
 
 It is possible to have several desktops at once, each an individual file, and
 each corresponding to a different project. Use the function
-=zk-index-desktop-select= to switch from working with one desktop to working
+=zk-desktop-select= to switch from working with one desktop to working
 with another.
 
 *** Working with notes on a desktop
@@ -558,18 +558,18 @@ can appear more than once, and the user can type on the desktop just like in
 a normal buffer --- for example, to create headings or simply to type notes.
 
 A zk-desktop buffers open in =fundamental-mode= by default, but this can be
-changed by setting the variable =zk-index-desktop-major-mode= to the symbol
+changed by setting the variable =zk-desktop-major-mode= to the symbol
 for a major mode. Consider setting this to =text-mode=, =outline-mode=, or
 =org-mode=.
 
 #+begin_src emacs-lisp
-(setq zk-index-desktop-major-mode 'outline-mode)
+(setq zk-desktop-major-mode 'outline-mode)
 #+end_src
 
 *** Adding notes to a desktop
 
 Each method of adding notes to the currently active desktop is accomplished
-via the same function: =zk-index-send-to-desktop=.
+via the same function: =zk-desktop-send-to-desktop=.
 
 When this function is called in the =zk-index= buffer itself, the note at
 point is sent to the desktop. If several notes are selected in the index, all
@@ -579,13 +579,12 @@ allow for sending a lot of relevant notes to a desktop at once.
 
 ** Embark Integration for ZK-Index and ZK-Desktop
 
-To enable integration with Embark, include =(zk-index-setup-embark)= in your
-init config.
+To enable integration with Embark, include =(zk-index-setup-embark)= and =(zk-desktop-setup-embark)= in your init config.
 
 This setup allows all index and desktop items to be recognized as zk-id
 Embark targets, making available all Embark actions in the =zk-id-map=.
 
-This also adds =zk-index-send-to-deskop= to =zk-id-map= and =zk-file-map=, to
+The latter adds =zk-desktop-send-to-deskop= to =zk-id-map= and =zk-file-map=, to
 facilitate sending files to desktop from the minibuffer or via =embark-act=
 in the zk-index buffer.
 

--- a/zk-desktop.el
+++ b/zk-desktop.el
@@ -1,0 +1,517 @@
+;;; zk-desktop.el --- Desktop environment for zk   -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022  Grant Rosson
+
+;; Author: Grant Rosson <https://github.com/localauthor>
+;; Created: January 25, 2022
+;; License: GPL-3.0-or-later
+;; Version: 0.1
+;; Homepage: https://github.com/localauthor/zk
+
+;; Package-Requires: ((emacs "25.1")(zk "0.3"))
+
+;; This program is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by the Free
+;; Software Foundation, either version 3 of the License, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+;; for more details.
+
+;; You should have received a copy of the GNU General Public License along
+;; with this program. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; ZK-Desktop: A place (or places) for collecting, grouping, arranging, and
+;; saving curated selections of notes (also in txhe form of clickable links).
+
+;; To enable integration with Embark, include '(zk-desktop-setup-embark)' in
+;; your init config.
+
+;;; Code:
+
+(require 'zk)
+(require 'zk-index)
+
+;;; Custom Variables
+
+(defgroup zk-desktop nil
+  "Desktop interface for zk."
+  :group 'text
+  :group 'files
+  :prefix "zk-desktop")
+
+(defcustom zk-desktop-directory nil
+  "Directory for saved ZK-Desktops."
+  :type 'directory)
+
+(defcustom zk-desktop-basename "*ZK-Desktop:"
+  "Basename for ZK-Desktops.
+The names of all ZK-Desktops should begin with this string."
+  :type 'string)
+
+(defcustom zk-desktop-prefix ""
+  "String to prepend to note names in ZK-Desktop."
+  :type 'string)
+
+(defcustom zk-desktop-major-mode nil
+  "Name of major-mode for ZK-Desktop buffers.
+The value should be a symbol that is a major mode command.
+If nil, buffers will be in `fundamental-mode'."
+  :type 'function)
+
+(defcustom zk-desktop-add-pos 'append
+  "Behavior for placement of notes in ZK-Desktop via `zk-desktop-send-to-desktop'.
+
+Options:
+1. `append - Place notes at end of current ZK-Desktop
+2. `prepend - Place notes at beginning of current ZK-Desktop
+3. `at-point - Place notes at current point of current ZK-Desktop
+
+To quickly change this setting, call `zk-desktop-add-toggle'."
+  :type '(choice (const :tag "Append" append)
+                 (const :tag "Prepend" prepend)
+                 (const :tag "At point" at-point)))
+
+(defface zk-desktop-button
+  '((t :inherit default))
+  "Face used for buttons in `zk-desktop-mode'.")
+
+
+;;; Declarations
+
+(defvar zk-desktop-current nil)
+
+
+;;; Embark Integration
+
+(defvar embark-multitarget-actions)
+(defvar embark-target-finders)
+(defvar embark-exporters-alist)
+
+(defun zk-desktop-setup-embark ()
+  "Setup Embark integration for `zk-desktop'."
+  (with-eval-after-load 'embark
+    (add-to-list 'embark-multitarget-actions 'zk-desktop-send-to-desktop)
+    (define-key zk-file-map (kbd "d") #'zk-desktop-send-to-desktop)
+    (define-key zk-id-map (kbd "d") #'zk-desktop-send-to-desktop)))
+
+;;; ZK-Desktop Minor Mode Settings
+
+(defvar zk-desktop-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-<up>") #'zk-desktop-move-line-up)
+    (define-key map (kbd "C-<down>") #'zk-desktop-move-line-down)
+    (define-key map [remap delete-char] #'zk-desktop-delete-char)
+    (define-key map [remap delete-backward-char] #'zk-desktop-delete-backward-char)
+    (define-key map [remap kill-region] #'zk-desktop-kill-region)
+    (define-key map [remap yank] #'zk-desktop-yank)
+    map)
+  "Keymap for ZK-Desktop buffers.")
+
+(define-minor-mode zk-desktop-mode
+  "Minor mode for `zk-desktop'."
+  :init-value nil
+  :keymap zk-desktop-map
+  (zk-desktop-make-buttons)
+  (when-let ((mode zk-desktop-major-mode))
+    (funcall mode))
+  ;;(setq truncate-lines t)
+  (setq-local zk-desktop-mode t))
+
+(defvar zk-desktop-button-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-<up>") #'zk-desktop-move-line-up)
+    (define-key map (kbd "C-<down>") #'zk-desktop-move-line-down)
+    (define-key map [remap kill-line] #'zk-desktop-kill-line)
+    (define-key map [remap delete-char] #'zk-desktop-delete-char)
+    (define-key map [remap kill-region] #'zk-desktop-kill-region)
+    (define-key map (kbd "v") #'zk-index-view-note)
+    (define-key map (kbd "n") #'zk-index-next-line)
+    (define-key map (kbd "p") #'zk-index-previous-line)
+    (define-key map [remap self-insert-command] 'ignore)
+    (set-keymap-parent map button-map)
+    map)
+  "Keymap for ZK-Desktop buttons.")
+
+;;; ZK-Desktop
+
+;;;###autoload
+(defun zk-desktop ()
+  "Open ZK-Desktop."
+  (interactive)
+  (let ((buffer (if (and zk-desktop-current
+                         (buffer-live-p (get-buffer zk-desktop-current)))
+                    zk-desktop-current
+                  (zk-desktop-select)))
+        (choice (unless (eq (current-buffer) zk-desktop-current)
+                  (read-char "Choice: \[s\]witch or \[p\]op-up?"))))
+    (pcase choice
+      ('?s (switch-to-buffer buffer))
+      ('?p (pop-to-buffer buffer
+                          '(display-buffer-at-bottom)))
+      (_ nil))))
+
+
+;;;###autoload
+(defun zk-desktop-select ()
+  "Select a ZK-Desktop to work with."
+  (interactive)
+  (unless zk-desktop-directory
+    (error "Please set `zk-desktop-directory' first"))
+  (let* ((last-command last-command)
+         (desktop
+          (completing-read "Select or Create ZK-Desktop: "
+                           (directory-files
+                            zk-desktop-directory
+                            nil
+                            (concat
+                             zk-desktop-basename
+                             ".*"))
+                           nil nil nil nil
+                           (concat zk-desktop-basename " ")))
+         (file (concat zk-desktop-directory "/" desktop)))
+    (if (file-exists-p (expand-file-name file))
+        (setq zk-desktop-current
+              (find-file-noselect file))
+      (progn
+        (generate-new-buffer desktop)
+        (setq zk-desktop-current desktop)))
+    (with-current-buffer zk-desktop-current
+      (setq require-final-newline 'visit-save)
+      (unless (bound-and-true-p truncate-lines)
+        (toggle-truncate-lines))
+      (set-visited-file-name file t t)
+      (zk-desktop-mode)
+      (save-buffer))
+    (if (and (not (eq last-command 'zk-desktop))
+             (y-or-n-p (format "Visit %s? " zk-desktop-current)))
+        (switch-to-buffer zk-desktop-current)
+      (message "Desktop set to: %s" zk-desktop-current)))
+  zk-desktop-current)
+
+(eval-and-compile
+  (define-button-type 'zk-desktop
+    'read-only t
+    'front-sticky t
+    'rear-sticky t
+    'keymap zk-desktop-button-map
+    'action 'zk-index-button-action
+    'help-echo 'zk-index-help-echo
+    'face 'zk-desktop-button
+    'cursor-face 'highlight))
+
+;;;###autoload
+(defun zk-desktop-make-buttons ()
+  "Re-make buttons in ZK-Desktop."
+  (interactive)
+  (when (and (string-match-p zk-desktop-basename (buffer-name))
+             (file-in-directory-p default-directory zk-desktop-directory))
+    (let ((inhibit-read-only t))
+      (save-excursion
+        ;; replace titles
+        (goto-char (point-min))
+        (let* ((zk-alist (zk--alist))
+               (ids (zk--id-list nil zk-alist)))
+          (while (re-search-forward zk-id-regexp nil t)
+            (let* ((beg (line-beginning-position))
+                   (end (line-end-position))
+                   (id  (progn
+                          (save-match-data
+                            (beginning-of-line)
+                            (when (re-search-forward "\\[\\[" end t)
+                              (replace-match ""))
+                            (when (re-search-forward "]]" end t)
+                              (replace-match "")))
+                          (match-string-no-properties 1)))
+                   (title (buffer-substring-no-properties beg (match-beginning 0)))
+                   (new-title (when (member id ids)
+                                (concat zk-desktop-prefix
+                                        (zk--parse-id 'title id zk-alist) " "))))
+              (beginning-of-line)
+              (if new-title
+                  (unless (string= title new-title)
+                    (progn
+                      (search-forward title end)
+                      (replace-match new-title)))
+                (progn
+                  (search-forward title end)
+                  (replace-match (propertize title 'face 'error))))
+              (end-of-line)))
+          ;; make buttons
+          (goto-char (point-min))
+          (while (re-search-forward zk-id-regexp nil t)
+            (let* ((beg (line-beginning-position))
+                   (end (line-end-position))
+                   (id (match-string-no-properties 1)))
+              (if (member id ids)
+                  (progn
+                    (make-text-button beg end 'type 'zk-desktop)
+                    (when zk-index-invisible-ids
+                      (beginning-of-line)
+                      ;; find zk-links and plain zk-ids
+                      (if (re-search-forward (zk-link-regexp) (line-end-position) t)
+                          (replace-match
+                           (propertize (match-string 0) 'invisible t) nil t)
+                        (progn
+                          (re-search-forward id)
+                          (replace-match
+                           (propertize id
+                                       'read-only t
+                                       'front-sticky t
+                                       'rear-nonsticky t))
+                          ;; enable invisibility in org-mode
+                          (overlay-put
+                           (make-overlay (match-beginning 0) (match-end 0))
+                           'invisible t))))
+                    (add-text-properties beg (+ beg 1)
+                                         '(front-sticky nil)))
+                (end-of-line)
+                (overlay-put (make-overlay (point) (point))
+                             'before-string
+                             (propertize" <- ID NOT FOUND" 'font-lock-face 'error))))
+            (end-of-line)))))))
+
+;;;###autoload
+(defun zk-desktop-send-to-desktop (&optional files)
+  "Send notes from ZK-Index to ZK-Desktop.
+In ZK-Index, works on note at point or notes in active region.
+Also works on FILES or group of files in minibuffer, and on zk-id
+at point."
+  ;; TODO check that zk-desktop is loaded
+  (interactive)
+  (unless zk-desktop-directory
+    (error "Please set `zk-desktop-directory' first"))
+  (let ((inhibit-read-only t)
+        (buffer) (items))
+    (cond ((zk--singleton-p files)
+           (unless
+               (ignore-errors
+                 (setq items (car (funcall zk-index-format-function files))))
+             (setq items
+                   (car
+                    (funcall
+                     zk-index-format-function
+                     (list (zk--parse-id 'file-path files)))))))
+          (files                        ; > 1 elements in files
+           (setq items
+                 (mapconcat
+                  #'identity
+                  (funcall zk-index-format-function files) "\n")))
+          ((eq major-mode 'zk-index-mode) ; no elements in files
+           (setq items (if (use-region-p)
+                           (buffer-substring
+                            (save-excursion
+                              (goto-char (region-beginning))
+                              (line-beginning-position))
+                            (save-excursion
+                              (goto-char (region-end))
+                              (line-end-position)))
+                         (buffer-substring
+                          (line-beginning-position)
+                          (line-end-position)))))
+          ((zk-file-p)                  ; no elements in files
+           (setq items
+                 (car
+                  (funcall
+                   zk-index-format-function
+                   (list buffer-file-name)))))
+          (t
+           (user-error "Don't know how to send this to desktop")))
+    (if (and zk-desktop-current
+             (buffer-live-p (get-buffer zk-desktop-current)))
+        (setq buffer zk-desktop-current)
+      (setq buffer (zk-desktop-select)))
+    (unless (get-buffer buffer)
+      (generate-new-buffer buffer))
+    (with-current-buffer buffer
+      (setq require-final-newline 'visit-save)
+      (pcase zk-desktop-add-pos
+        ('append (progn
+                   (goto-char (point-max))
+                   (beginning-of-line)
+                   (when (looking-at-p ".")
+                     (end-of-line)
+                     (newline))))
+        ('prepend (progn
+                    (goto-char (point-min))))
+        ('at-point (goto-char (point))))
+      (insert items "\n")
+      (beginning-of-line)
+      (unless (bound-and-true-p truncate-lines)
+        (toggle-truncate-lines))
+      (zk-desktop-mode))
+    (if (eq major-mode 'zk-index-mode)
+        (message "Sent to %s - press D to switch" buffer)
+      (message "Sent to %s" buffer))))
+
+(defun zk-desktop-add-toggle ()
+  "Set `zk-desktop-add-pos' interactively."
+  (interactive)
+  (let ((choice (read-char "Choice: \[a\]ppend; \[p\]repend; at-\[P\]oint")))
+    (pcase choice
+      ('?a (setq zk-desktop-add-pos 'append))
+      ('?p (setq zk-desktop-add-pos 'prepend))
+      ('?P (setq zk-desktop-add-pos 'at-point)))))
+
+;;;###autoload
+(defun zk-desktop-switch-to-desktop ()
+  "Switch to ZK-Desktop.
+With prefix-argument, raise ZK-Desktop in other frame."
+  (interactive)
+  (unless (and zk-desktop-current
+               (buffer-live-p (get-buffer zk-desktop-current)))
+    (zk-desktop-select))
+  (let ((buffer zk-desktop-current))
+    (if current-prefix-arg
+        (if (get-buffer-window buffer 'visible)
+            (display-buffer-pop-up-frame
+             buffer
+             ;; not general
+             '((pop-up-frame-parameters . ((top . 80)
+                                           (left . 850)
+                                           (width . 80)
+                                           (height . 35)))))
+          (switch-to-buffer-other-frame buffer))
+      (switch-to-buffer buffer))))
+
+
+;;; ZK-Desktop Keymap Commands
+
+(defun zk-desktop-move-line-down ()
+  "Move line at point down in ZK-Desktop buffer."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (forward-line 1)
+    (transpose-lines 1)
+    (forward-line -1)
+    (when zk-index-invisible-ids
+      (zk-desktop-make-buttons))))
+
+(defun zk-desktop-move-line-up ()
+  "Move line at point up in ZK-Desktop buffer."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (transpose-lines 1)
+    (forward-line -2)
+    (when zk-index-invisible-ids
+      (zk-desktop-make-buttons))))
+
+(defun zk-desktop-delete-region-maybe ()
+  "Maybe delete region in `zk-desktop-mode'."
+  (cond ((and (not (use-region-p))
+              (zk-index--button-at-point-p))
+         (delete-region (line-beginning-position)
+                        (line-end-position)))
+        ((and (use-region-p)
+              (zk-index--button-at-point-p (region-beginning))
+              (not (zk-index--button-at-point-p (region-end))))
+         (delete-region (save-excursion
+                          (goto-char (region-beginning))
+                          (line-beginning-position))
+                        (region-end))
+         t)
+        ((and (use-region-p)
+              (not (zk-index--button-at-point-p (region-beginning)))
+              (zk-index--button-at-point-p (region-end)))
+         (delete-region (region-beginning)
+                        (save-excursion
+                          (goto-char (region-end))
+                          (line-end-position)))
+         t)
+        ((and (use-region-p)
+              (zk-index--button-at-point-p (region-beginning))
+              (zk-index--button-at-point-p (region-end)))
+         (delete-region
+          (save-excursion
+            (goto-char (region-beginning))
+            (line-beginning-position))
+          (save-excursion
+            (goto-char (region-end))
+            (line-end-position)))
+         t)
+        ((use-region-p)
+         (delete-region (region-beginning)
+                        (region-end))
+         t)))
+
+(defun zk-desktop-delete-char ()
+  "Wrapper around `delete-char' for `zk-desktop-mode'."
+  (interactive)
+  (unless (and (and (looking-back zk-id-regexp
+                                  (line-beginning-position))
+                    (looking-at "$"))
+               (save-excursion
+                 (beginning-of-line)
+                 (zk-index--button-at-point-p)))
+    (let ((inhibit-read-only t))
+      (unless (zk-desktop-delete-region-maybe)
+        (funcall #'delete-char (or current-prefix-arg 1))))))
+
+(defun zk-desktop-delete-backward-char ()
+  "Wrapper around `delete-backward-char' for `zk-desktop-mode'."
+  (interactive)
+  (unless (and (looking-back zk-id-regexp
+                             (line-beginning-position))
+               (save-excursion
+                 (beginning-of-line)
+                 (zk-index--button-at-point-p)))
+    (let ((inhibit-read-only t))
+      (unless (zk-desktop-delete-region-maybe)
+        (funcall #'delete-char (or current-prefix-arg -1))))))
+
+(defun zk-desktop-kill-line ()
+  "Kill line in `zk-desktop-mode'."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (if (not (zk-index--button-at-point-p))
+        (kill-line)
+      (kill-region (line-beginning-position)
+                   (line-end-position)))))
+
+(defun zk-desktop-kill-region ()
+  "Wrapper around `kill-region' for `zk-desktop-mode'."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (cond ((and (use-region-p)
+                (zk-index--button-at-point-p (region-beginning))
+                (not (zk-index--button-at-point-p (region-end))))
+           (kill-region (save-excursion
+                          (goto-char (region-beginning))
+                          (line-beginning-position))
+                        (region-end)))
+          ((and (use-region-p)
+                (not (zk-index--button-at-point-p (region-beginning)))
+                (zk-index--button-at-point-p (region-end)))
+           (kill-region (region-beginning)
+                        (save-excursion
+                          (goto-char (region-end))
+                          (line-end-position))))
+          ((and (use-region-p)
+                (zk-index--button-at-point-p (region-beginning))
+                (zk-index--button-at-point-p (region-end)))
+           (kill-region
+            (save-excursion
+              (goto-char (region-beginning))
+              (line-beginning-position))
+            (save-excursion
+              (goto-char (region-end))
+              (line-end-position))))
+          ((use-region-p)
+           (kill-region (region-beginning)
+                        (region-end))))))
+
+(defun zk-desktop-yank ()
+  "Wrapper around `yank' for `zk-desktop-mode'."
+  (interactive)
+  (let ((inhibit-read-only t))
+    (yank)
+    (zk-desktop-make-buttons)))
+
+
+(provide 'zk-desktop)
+
+;;; zk-desktop.el ends here

--- a/zk-desktop.el
+++ b/zk-desktop.el
@@ -281,7 +281,6 @@ To quickly change this setting, call `zk-desktop-add-toggle'."
 In ZK-Index, works on note at point or notes in active region.
 Also works on FILES or group of files in minibuffer, and on zk-id
 at point."
-  ;; TODO check that zk-desktop is loaded
   (interactive)
   (unless zk-desktop-directory
     (error "Please set `zk-desktop-directory' first"))
@@ -320,7 +319,7 @@ at point."
                    zk-index-format-function
                    (list buffer-file-name)))))
           (t
-           (user-error "Don't know how to send this to desktop")))
+           (user-error "No item to send to desktop")))
     (if (and zk-desktop-current
              (buffer-live-p (get-buffer zk-desktop-current)))
         (setq buffer zk-desktop-current)

--- a/zk-index.el
+++ b/zk-index.el
@@ -5,7 +5,7 @@
 ;; Author: Grant Rosson <https://github.com/localauthor>
 ;; Created: January 25, 2022
 ;; License: GPL-3.0-or-later
-;; Version: 0.7
+;; Version: 0.8
 ;; Homepage: https://github.com/localauthor/zk
 
 ;; Package-Requires: ((emacs "27.1")(zk "0.3"))

--- a/zk-index.el
+++ b/zk-index.el
@@ -1,4 +1,4 @@
-;;; zk-index.el --- Index and Desktop for zk   -*- lexical-binding: t; -*-
+;;; zk-index.el --- Index for zk   -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2022  Grant Rosson
 
@@ -25,13 +25,8 @@
 
 ;;; Commentary:
 
-;; Two interfaces for zk:
-
 ;; ZK-Index: A sortable, searchable, narrowable, semi-persistent selection of
 ;; notes, in the form of clickable links.
-
-;; ZK-Desktop: A place (or places) for collecting, grouping, arranging, and
-;; saving curated selections of notes (also in the form of clickable links).
 
 ;; To enable integration with Embark, include '(zk-index-setup-embark)' in
 ;; your init config.
@@ -44,7 +39,7 @@
 ;;; Custom Variables
 
 (defgroup zk-index nil
-  "Index and Desktop interfaces for zk."
+  "Index interface for zk."
   :group 'text
   :group 'files
   :prefix "zk-index")
@@ -85,42 +80,6 @@ See the default function `zk-index-button-display-action' for an
 example."
   :type 'function)
 
-(defcustom zk-index-desktop-directory nil
-  "Directory for saved ZK-Desktops."
-  :type 'directory)
-
-(defcustom zk-index-desktop-basename "*ZK-Desktop:"
-  "Basename for ZK-Desktops.
-The names of all ZK-Desktops should begin with this string."
-  :type 'string)
-
-(defcustom zk-index-desktop-prefix ""
-  "String to prepend to note names in ZK-Desktop."
-  :type 'string)
-
-(defcustom zk-index-desktop-major-mode nil
-  "Name of major-mode for ZK-Desktop buffers.
-The value should be a symbol that is a major mode command.
-If nil, buffers will be in `fundamental-mode'."
-  :type 'function)
-
-(defcustom zk-index-desktop-add-pos 'append
-  "Behavior for placement of notes in ZK-Desktop via `zk-index-send-to-desktop'.
-
-Options:
-1. `append - Place notes at end of current ZK-Desktop
-2. `prepend - Place notes at beginning of current ZK-Desktop
-3. `at-point - Place notes at current point of current ZK-Desktop
-
-To quickly change this setting, call `zk-index-desktop-add-toggle'."
-  :type '(choice (const :tag "Append" append)
-                 (const :tag "Prepend" prepend)
-                 (const :tag "At point" at-point)))
-
-(defface zk-index-desktop-button
-  '((t :inherit default))
-  "Face used for buttons in `zk-index-desktop-mode'.")
-
 ;;; ZK-Index Major Mode Settings
 
 (defvar zk-index-mode-line-orig nil
@@ -158,43 +117,6 @@ To quickly change this setting, call `zk-index-desktop-add-toggle'."
   (setq-local show-paren-mode nil)
   (setq cursor-type nil))
 
-;;; ZK-Desktop Minor Mode Settings
-
-(defvar zk-index-desktop-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-<up>") #'zk-index-move-line-up)
-    (define-key map (kbd "C-<down>") #'zk-index-move-line-down)
-    (define-key map [remap delete-char] #'zk-index-desktop-delete-char)
-    (define-key map [remap delete-backward-char] #'zk-index-desktop-delete-backward-char)
-    (define-key map [remap kill-region] #'zk-index-desktop-kill-region)
-    (define-key map [remap yank] #'zk-index-desktop-yank)
-    map)
-  "Keymap for ZK-Desktop buffers.")
-
-(define-minor-mode zk-index-desktop-mode
-  "Minor mode for `zk-index-desktop'."
-  :init-value nil
-  :keymap zk-index-desktop-map
-  (zk-index-desktop-make-buttons)
-  (when-let ((mode zk-index-desktop-major-mode))
-    (funcall mode))
-  ;;(setq truncate-lines t)
-  (setq-local zk-index-desktop-mode t))
-
-(defvar zk-index-desktop-button-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-<up>") #'zk-index-move-line-up)
-    (define-key map (kbd "C-<down>") #'zk-index-move-line-down)
-    (define-key map [remap kill-line] #'zk-index-desktop-kill-line)
-    (define-key map [remap delete-char] #'zk-index-desktop-delete-char)
-    (define-key map [remap kill-region] #'zk-index-desktop-kill-region)
-    (define-key map (kbd "v") #'zk-index-view-note)
-    (define-key map (kbd "n") #'zk-index-next-line)
-    (define-key map (kbd "p") #'zk-index-previous-line)
-    (define-key map [remap self-insert-command] 'ignore)
-    (set-keymap-parent map button-map)
-    map)
-  "Keymap for ZK-Desktop buttons.")
 
 ;;; Declarations
 
@@ -202,7 +124,6 @@ To quickly change this setting, call `zk-index-desktop-add-toggle'."
 (defvar zk-index-last-format-function nil)
 (defvar zk-index-query-mode-line nil)
 (defvar zk-index-query-terms nil)
-(defvar zk-index-desktop-current nil)
 (defvar zk-search-history)
 
 (declare-function zk-file-p zk)
@@ -393,9 +314,10 @@ Optionally refresh with FILES, using FORMAT-FN, SORT-FN, BUF-NAME."
 
 (defun zk-index-button-display-action (file buffer)
   "Function to display FILE or BUFFER on button press in Index and Desktop."
-  (if (and zk-index-desktop-directory
-	       (file-in-directory-p zk-index-desktop-directory
-				                default-directory))
+  ;; TODO check that zk-desktop is loaded
+  (if (and zk-desktop-directory
+	   (file-in-directory-p zk-desktop-directory
+				default-directory))
       ;; display action for ZK-Desktop
       (progn
         (if (one-window-p)
@@ -703,7 +625,7 @@ Takes an option POS position argument."
                     (button-at (point)))))
     (when (and button
                (or (eq (button-type button) 'zk-index)
-                   (eq (button-type button) 'zk-index-desktop)))
+                   (eq (button-type button) 'zk-desktop)))
       (save-excursion
         (re-search-forward zk-id-regexp)
         (match-string-no-properties 1)))))
@@ -785,228 +707,6 @@ If `zk-index-auto-scroll' is non-nil, show note in other window."
             (zk-index-view-note)))
       (forward-button -1))))
 
-
-;;; ZK-Desktop
-;; index's more flexible, savable cousin; a place to collect and order notes
-;; in the form of links
-
-;;;###autoload
-(defun zk-index-desktop ()
-  "Open ZK-Desktop."
-  (interactive)
-  (let ((buffer (if (and zk-index-desktop-current
-                         (buffer-live-p (get-buffer zk-index-desktop-current)))
-                    zk-index-desktop-current
-                  (zk-index-desktop-select)))
-        (choice (unless (eq (current-buffer) zk-index-desktop-current)
-                  (read-char "Choice: \[s\]witch or \[p\]op-up?"))))
-    (pcase choice
-      ('?s (switch-to-buffer buffer))
-      ('?p (pop-to-buffer buffer
-                          '(display-buffer-at-bottom)))
-      (_ nil))))
-
-
-;;;###autoload
-(defun zk-index-desktop-select ()
-  "Select a ZK-Desktop to work with."
-  (interactive)
-  (unless zk-index-desktop-directory
-    (error "Please set `zk-index-desktop-directory' first"))
-  (let* ((last-command last-command)
-         (desktop
-          (completing-read "Select or Create ZK-Desktop: "
-                           (directory-files
-                            zk-index-desktop-directory
-                            nil
-                            (concat
-                             zk-index-desktop-basename
-                             ".*"))
-                           nil nil nil nil
-                           (concat zk-index-desktop-basename " ")))
-         (file (concat zk-index-desktop-directory "/" desktop)))
-    (if (file-exists-p (expand-file-name file))
-        (setq zk-index-desktop-current
-              (find-file-noselect file))
-      (progn
-        (generate-new-buffer desktop)
-        (setq zk-index-desktop-current desktop)))
-    (with-current-buffer zk-index-desktop-current
-      (setq require-final-newline 'visit-save)
-      (unless (bound-and-true-p truncate-lines)
-        (toggle-truncate-lines))
-      (set-visited-file-name file t t)
-      (zk-index-desktop-mode)
-      (save-buffer))
-    (if (and (not (eq last-command 'zk-index-desktop))
-             (y-or-n-p (format "Visit %s? " zk-index-desktop-current)))
-        (switch-to-buffer zk-index-desktop-current)
-      (message "Desktop set to: %s" zk-index-desktop-current)))
-  zk-index-desktop-current)
-
-(eval-and-compile
-  (define-button-type 'zk-index-desktop
-    'read-only t
-    'front-sticky t
-    'rear-sticky t
-    'keymap zk-index-desktop-button-map
-    'action 'zk-index-button-action
-    'help-echo 'zk-index-help-echo
-    'face 'zk-index-desktop-button
-    'cursor-face 'highlight))
-
-;;;###autoload
-(defun zk-index-desktop-make-buttons ()
-  "Re-make buttons in ZK-Desktop."
-  (interactive)
-  (when (and (string-match-p zk-index-desktop-basename (buffer-name))
-             (file-in-directory-p default-directory zk-index-desktop-directory))
-    (let ((inhibit-read-only t))
-      (save-excursion
-        ;; replace titles
-        (goto-char (point-min))
-        (let* ((zk-alist (zk--alist))
-               (ids (zk--id-list nil zk-alist)))
-          (while (re-search-forward zk-id-regexp nil t)
-            (let* ((beg (line-beginning-position))
-                   (end (line-end-position))
-                   (id  (progn
-                          (save-match-data
-                            (beginning-of-line)
-                            (when (re-search-forward "\\[\\[" end t)
-                              (replace-match ""))
-                            (when (re-search-forward "]]" end t)
-                              (replace-match "")))
-                          (match-string-no-properties 1)))
-                   (title (buffer-substring-no-properties beg (match-beginning 0)))
-                   (new-title (when (member id ids)
-                                (concat zk-index-desktop-prefix
-                                        (zk--parse-id 'title id zk-alist) " "))))
-              (beginning-of-line)
-              (if new-title
-                  (unless (string= title new-title)
-                    (progn
-                      (search-forward title end)
-                      (replace-match new-title)))
-                (progn
-                  (search-forward title end)
-                  (replace-match (propertize title 'face 'error))))
-              (end-of-line)))
-          ;; make buttons
-          (goto-char (point-min))
-          (while (re-search-forward zk-id-regexp nil t)
-            (let* ((beg (line-beginning-position))
-                   (end (line-end-position))
-                   (id (match-string-no-properties 1)))
-              (if (member id ids)
-                  (progn
-                    (make-text-button beg end 'type 'zk-index-desktop)
-                    (when zk-index-invisible-ids
-                      (beginning-of-line)
-                      ;; find zk-links and plain zk-ids
-                      (if (re-search-forward (zk-link-regexp) (line-end-position) t)
-                          (replace-match
-                           (propertize (match-string 0) 'invisible t) nil t)
-                        (progn
-                          (re-search-forward id)
-                          (replace-match
-                           (propertize id
-                                       'read-only t
-                                       'front-sticky t
-                                       'rear-nonsticky t))
-                          ;; enable invisibility in org-mode
-                          (overlay-put
-                           (make-overlay (match-beginning 0) (match-end 0))
-                           'invisible t))))
-                    (add-text-properties beg (+ beg 1)
-                                         '(front-sticky nil)))
-                (end-of-line)
-                (overlay-put (make-overlay (point) (point))
-                             'before-string
-                             (propertize" <- ID NOT FOUND" 'font-lock-face 'error))))
-            (end-of-line)))))))
-
-;;;###autoload
-(defun zk-index-send-to-desktop (&optional files)
-  "Send notes from ZK-Index to ZK-Desktop.
-In ZK-Index, works on note at point or notes in active region.
-Also works on FILES or group of files in minibuffer, and on zk-id
-at point."
-  (interactive)
-  (unless zk-index-desktop-directory
-    (error "Please set `zk-index-desktop-directory' first"))
-  (let ((inhibit-read-only t)
-        (buffer) (items))
-    (cond ((zk--singleton-p files)
-           (unless
-               (ignore-errors
-                 (setq items (car (funcall zk-index-format-function files))))
-             (setq items
-                   (car
-                    (funcall
-                     zk-index-format-function
-                     (list (zk--parse-id 'file-path files)))))))
-          (files                        ; > 1 elements in files
-           (setq items
-                 (mapconcat
-                  #'identity
-                  (funcall zk-index-format-function files) "\n")))
-          ((eq major-mode 'zk-index-mode) ; no elements in files
-           (setq items (if (use-region-p)
-                           (buffer-substring
-                            (save-excursion
-                              (goto-char (region-beginning))
-                              (line-beginning-position))
-                            (save-excursion
-                              (goto-char (region-end))
-                              (line-end-position)))
-                         (buffer-substring
-                          (line-beginning-position)
-                          (line-end-position)))))
-          ((zk-file-p)                  ; no elements in files
-           (setq items
-                 (car
-                  (funcall
-                   zk-index-format-function
-                   (list buffer-file-name)))))
-          (t
-           (user-error "Don't know how to send this to desktop")))
-    (if (and zk-index-desktop-current
-             (buffer-live-p (get-buffer zk-index-desktop-current)))
-        (setq buffer zk-index-desktop-current)
-      (setq buffer (zk-index-desktop-select)))
-    (unless (get-buffer buffer)
-      (generate-new-buffer buffer))
-    (with-current-buffer buffer
-      (setq require-final-newline 'visit-save)
-      (pcase zk-index-desktop-add-pos
-        ('append (progn
-                   (goto-char (point-max))
-                   (beginning-of-line)
-                   (when (looking-at-p ".")
-                     (end-of-line)
-                     (newline))))
-        ('prepend (progn
-                    (goto-char (point-min))))
-        ('at-point (goto-char (point))))
-      (insert items "\n")
-      (beginning-of-line)
-      (unless (bound-and-true-p truncate-lines)
-        (toggle-truncate-lines))
-      (zk-index-desktop-mode))
-    (if (eq major-mode 'zk-index-mode)
-        (message "Sent to %s - press D to switch" buffer)
-      (message "Sent to %s" buffer))))
-
-(defun zk-index-desktop-add-toggle ()
-  "Set `zk-index-desktop-add-pos' interactively."
-  (interactive)
-   (let ((choice (read-char "Choice: \[a\]ppend; \[p\]repend; at-\[P\]oint")))
-     (pcase choice
-      ('?a (setq zk-index-desktop-add-pos 'append))
-      ('?p (setq zk-index-desktop-add-pos 'prepend))
-      ('?P (setq zk-index-desktop-add-pos 'at-point)))))
-
 ;;;###autoload
 (defun zk-index-switch-to-index ()
   "Switch to ZK-Index buffer."
@@ -1018,158 +718,6 @@ at point."
         (zk-index-refresh)))
     (switch-to-buffer buffer)))
 
-;;;###autoload
-(defun zk-index-switch-to-desktop ()
-  "Switch to ZK-Desktop.
-With prefix-argument, raise ZK-Desktop in other frame."
-  (interactive)
-  (unless (and zk-index-desktop-current
-               (buffer-live-p (get-buffer zk-index-desktop-current)))
-    (zk-index-desktop-select))
-  (let ((buffer zk-index-desktop-current))
-    (if current-prefix-arg
-        (if (get-buffer-window buffer 'visible)
-            (display-buffer-pop-up-frame
-             buffer
-             ;; not general
-             '((pop-up-frame-parameters . ((top . 80)
-                                           (left . 850)
-                                           (width . 80)
-                                           (height . 35)))))
-          (switch-to-buffer-other-frame buffer))
-      (switch-to-buffer buffer))))
-
-;;; ZK-Desktop Keymap Commands
-
-(defun zk-index-move-line-down ()
-  "Move line at point down in ZK-Desktop buffer."
-  (interactive)
-  (let ((inhibit-read-only t))
-    (forward-line 1)
-    (transpose-lines 1)
-    (forward-line -1)
-    (when zk-index-invisible-ids
-      (zk-index-desktop-make-buttons))))
-
-(defun zk-index-move-line-up ()
-  "Move line at point up in ZK-Desktop buffer."
-  (interactive)
-  (let ((inhibit-read-only t))
-    (transpose-lines 1)
-    (forward-line -2)
-    (when zk-index-invisible-ids
-      (zk-index-desktop-make-buttons))))
-
-(defun zk-index-desktop-delete-region-maybe ()
-  "Maybe delete region in `zk-index-desktop-mode'."
-  (cond ((and (not (use-region-p))
-              (zk-index--button-at-point-p))
-         (delete-region (line-beginning-position)
-                        (line-end-position)))
-        ((and (use-region-p)
-              (zk-index--button-at-point-p (region-beginning))
-              (not (zk-index--button-at-point-p (region-end))))
-         (delete-region (save-excursion
-                          (goto-char (region-beginning))
-                          (line-beginning-position))
-                        (region-end))
-         t)
-        ((and (use-region-p)
-              (not (zk-index--button-at-point-p (region-beginning)))
-              (zk-index--button-at-point-p (region-end)))
-         (delete-region (region-beginning)
-                        (save-excursion
-                          (goto-char (region-end))
-                          (line-end-position)))
-         t)
-        ((and (use-region-p)
-              (zk-index--button-at-point-p (region-beginning))
-              (zk-index--button-at-point-p (region-end)))
-         (delete-region
-          (save-excursion
-            (goto-char (region-beginning))
-            (line-beginning-position))
-          (save-excursion
-            (goto-char (region-end))
-            (line-end-position)))
-         t)
-        ((use-region-p)
-         (delete-region (region-beginning)
-                        (region-end))
-         t)))
-
-(defun zk-index-desktop-delete-char ()
-  "Wrapper around `delete-char' for `zk-index-desktop-mode'."
-  (interactive)
-  (unless (and (and (looking-back zk-id-regexp
-                                  (line-beginning-position))
-                    (looking-at "$"))
-               (save-excursion
-                 (beginning-of-line)
-                 (zk-index--button-at-point-p)))
-    (let ((inhibit-read-only t))
-      (unless (zk-index-desktop-delete-region-maybe)
-        (funcall #'delete-char (or current-prefix-arg 1))))))
-
-(defun zk-index-desktop-delete-backward-char ()
-  "Wrapper around `delete-backward-char' for `zk-index-desktop-mode'."
-  (interactive)
-  (unless (and (looking-back zk-id-regexp
-                             (line-beginning-position))
-               (save-excursion
-                 (beginning-of-line)
-                 (zk-index--button-at-point-p)))
-    (let ((inhibit-read-only t))
-      (unless (zk-index-desktop-delete-region-maybe)
-        (funcall #'delete-char (or current-prefix-arg -1))))))
-
-(defun zk-index-desktop-kill-line ()
-  "Kill line in `zk-index-desktop-mode'."
-  (interactive)
-  (let ((inhibit-read-only t))
-    (if (not (zk-index--button-at-point-p))
-        (kill-line)
-      (kill-region (line-beginning-position)
-                   (line-end-position)))))
-
-(defun zk-index-desktop-kill-region ()
-  "Wrapper around `kill-region' for `zk-index-desktop-mode'."
-  (interactive)
-  (let ((inhibit-read-only t))
-    (cond ((and (use-region-p)
-                (zk-index--button-at-point-p (region-beginning))
-                (not (zk-index--button-at-point-p (region-end))))
-           (kill-region (save-excursion
-                            (goto-char (region-beginning))
-                            (line-beginning-position))
-                          (region-end)))
-          ((and (use-region-p)
-                (not (zk-index--button-at-point-p (region-beginning)))
-                (zk-index--button-at-point-p (region-end)))
-           (kill-region (region-beginning)
-                          (save-excursion
-                            (goto-char (region-end))
-                            (line-end-position))))
-          ((and (use-region-p)
-                (zk-index--button-at-point-p (region-beginning))
-                (zk-index--button-at-point-p (region-end)))
-           (kill-region
-            (save-excursion
-              (goto-char (region-beginning))
-              (line-beginning-position))
-            (save-excursion
-              (goto-char (region-end))
-              (line-end-position))))
-          ((use-region-p)
-           (kill-region (region-beginning)
-                          (region-end))))))
-
-(defun zk-index-desktop-yank ()
-  "Wrapper around `yank' for `zk-index-desktop-mode'."
-  (interactive)
-  (let ((inhibit-read-only t))
-    (yank)
-    (zk-index-desktop-make-buttons)))
 
 (provide 'zk-index)
 

--- a/zk.el
+++ b/zk.el
@@ -273,7 +273,7 @@ Adds zk-id as an Embark target, and adds `zk-id-map' and
 
 (defun zk--singleton-p (list)
   "Return non-NIL if LIST is not null, is a list, and has a single element."
-  (and (not (null list))
+  (and list
        (listp list)
        (null (cdr list))))
 


### PR DESCRIPTION
@boyechko What do you think about `zk-desktop` being moved to its own package? The only reason they are both in `zk-index` is that I wrote them concurrently. Can be done pretty cleanly.