### PR TITLE
Refactor zk--format and zk-format-function

### DIFF
--- a/zk.el
+++ b/zk.el
@@ -172,7 +172,7 @@ Must take a single STRING argument."
 See `zk-current-notes' for details."
   :type 'function)
 
-(defcustom zk-format-function #'zk--format-function
+(defcustom zk-format-function #'zk--format-default
   "User-defined function for formatting zk file information.
 The function should accept three variables: FORMAT-SPEC, ID, and
 TITLE. See `zk--format' for details."
@@ -778,7 +778,7 @@ Optionally call a custom function by setting the variable
 
 ;;; Insert Link
 
-(defun zk--format-function (format id title)
+(defun zk--format-default (format id title)
   "Format ID and TITLE based on the `format-spec' FORMAT.
 This is the default function set in `zk-format-function' and used by
 `zk--format' therwise, replace the sequence `%t' with the TITLE and
@@ -788,7 +788,7 @@ This is the default function set in `zk-format-function' and used by
 (defmacro zk--format (format id title)
   "Format ID and TITLE based on the `format-spec' FORMAT.
 This macro merely calls the function set in `zk-format-function',
-which defaults to `zk--format-function'."
+which defaults to `zk--format-default'."
   `(funcall zk-format-function ,format ,id ,title))
 
 ;;;###autoload

--- a/zk.el
+++ b/zk.el
@@ -172,10 +172,10 @@ Must take a single STRING argument."
 See `zk-current-notes' for details."
   :type 'function)
 
-(defcustom zk-format-function #'zk--format-default
-  "User-defined function for formatting zk file information.
-The function should accept three variables: FORMAT-SPEC, ID, and
-TITLE. See `zk--format' for details."
+(defcustom zk-format-function #'zk-format-id-and-title
+  "Function for formatting zk file information.
+It should accept three variables: FORMAT-SPEC, ID, and TITLE. See
+`zk--format' for details."
   :type 'function)
 
 ;; Format variables
@@ -778,7 +778,7 @@ Optionally call a custom function by setting the variable
 
 ;;; Insert Link
 
-(defun zk--format-default (format id title)
+(defun zk-format-id-and-title (format id title)
   "Format ID and TITLE based on the `format-spec' FORMAT.
 This is the default function set in `zk-format-function' and used by
 `zk--format' therwise, replace the sequence `%t' with the TITLE and
@@ -788,7 +788,7 @@ This is the default function set in `zk-format-function' and used by
 (defmacro zk--format (format id title)
   "Format ID and TITLE based on the `format-spec' FORMAT.
 This macro merely calls the function set in `zk-format-function',
-which defaults to `zk--format-default'."
+which defaults to `zk-format-id-and-title'."
   `(funcall zk-format-function ,format ,id ,title))
 
 ;;;###autoload

--- a/zk.el
+++ b/zk.el
@@ -172,7 +172,7 @@ Must take a single STRING argument."
 See `zk-current-notes' for details."
   :type 'function)
 
-(defcustom zk-format-function nil
+(defcustom zk-format-function #'zk--format-function
   "User-defined function for formatting zk file information.
 The function should accept three variables: FORMAT-SPEC, ID, and
 TITLE. See `zk--format' for details."
@@ -778,13 +778,18 @@ Optionally call a custom function by setting the variable
 
 ;;; Insert Link
 
-(defun zk--format (format id title)
+(defun zk--format-function (format id title)
   "Format ID and TITLE based on the `format-spec' FORMAT.
-If `zk-format-function' is set, call that function. Otherwise, replace
-the sequence `%t' with the TITLE and `%i' with the ID."
-  (if (functionp zk-format-function)
-      (funcall zk-format-function format id title)
-    (format-spec format `((?i . ,id) (?t . ,title)))))
+This is the default function set in `zk-format-function' and used by
+`zk--format' therwise, replace the sequence `%t' with the TITLE and
+`%i' with the ID."
+  (format-spec format `((?i . ,id) (?t . ,title))))
+
+(defmacro zk--format (format id title)
+  "Format ID and TITLE based on the `format-spec' FORMAT.
+This macro merely calls the function set in `zk-format-function',
+which defaults to `zk--format-function'."
+  `(funcall zk-format-function ,format ,id ,title))
 
 ;;;###autoload
 (defun zk-insert-link (id &optional title)


### PR DESCRIPTION
I thought I was being clever in "overloading" `zk--format` to call `zk-format-function` if it is set, and to do the default formatting otherwise. However, when writing `zk-format-function` for my use-case, I realized it would be useful to have an option of calling the default formatter in some cases. While it is possible to do that by lexically clearing `zk-format-function` before calling `zk--format`, that seems hacky:

``` emacs-lisp
(defun my-custom-zk-format (format id title)
  (if (not (some-test-p id))
      (let ((zk-format-function nil))
        (zk--format format id title))
    ;; do the formatting on my own
    ...))
```

With this refactoring, the above can become:

``` emacs-lisp
(defun my-custom-zk-format (format id title)
  (if (not (some-test-p id))
      (zk--format-function format id title)
    ;; do the formatting on my own
    ...))
```

There is no change in the behavior; the default formatter is just moved to a new function, `zk--format-function`, while `zk--format` becomes a very simple macro to call whatever `zk-format-function` is set to. In effect, the macro just acts as syntactic sugar to avoid having to type the lengthy `(funcall zk-format-function format id title)` all the time. Since the macro is so simple, does not ever need to change, and the biggest downside of macros --- they can't be used in `mapcar`, for example --- is not an issue given its three arguments, there shoulnd't be any surprises.