### PR TITLE
Add zk-insert-header command as migration utility

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,6 +13,7 @@
     - [[#link-hint.el][Support for link-hint.el]]
   - [[#list-backlinks][List Backlinks]]
   - [[#smart-new-note-creation][Smart New-Note Creation]]
+  - [[#migration-utilities][Migration Utilities]]
   - [[#insert-links][Insert Links]]
   - [[#search][Search]]
     - [[#alternative-search-functions-using-consult-grep][Alternative Search Functions, using Consult-Grep]]
@@ -315,6 +316,20 @@ Zettelkasten implementation and it persists here by custom only. It would be
 trivial to alter this function to behave perhaps more sensibly, for example
 by using the selected region in its entirety as the body and prompting for a
 title. For now, though, custom prevails.
+
+** Migration Utilities
+
+*** Insert Header
+
+Calling the =zk-insert-header= command inserts a header by means of
+=zk-new-note-header-function= based on the file name of the current buffer
+into the current buffer.
+
+This is useful if you migrated existing files into your =zk-directory= and
+renamed them to the zk file name scheme.
+
+You can change the suggested ID and title. Use the command
+=zk-insert-header-and-rename= to rename the file name of the note afterwards.
 
 ** Insert Links
 

--- a/zk.el
+++ b/zk.el
@@ -314,6 +314,11 @@ The value is based on `zk-link-format' and `zk-id-regexp'."
   (when (string-match (zk-file-name-regexp) file)
     (match-string-no-properties 1 file)))
 
+(defun zk--file-title (file)
+  "Return the TITLE of the given zk FILE."
+  (when (string-match (zk-file-name-regexp) file)
+    (match-string-no-properties 2 file)))
+
 (defun zk-file-p (&optional file strict)
   "Return t if FILE is a zk-file.
 If FILE is not given, get it from variable `buffer-file-name'.
@@ -661,6 +666,34 @@ Optionally use ORIG-ID for backlink."
       (zk--insert-link-and-title orig-id (zk--parse-id 'title orig-id))
       (newline)))
   (insert "===\n\n"))
+
+;;;###autoload
+(defun zk-insert-header (id title)
+  "Insert header into current note buffer.
+ID and TITLE are prompted for with default values derived
+from current `buffer-file-name'.
+
+This command is useful for migrating pre-existing note files
+which do not have a zk header but already have a zk-compatible
+file name."
+  (interactive
+   (list
+    (read-string "Enter ID: " (zk--file-id buffer-file-name))
+    (read-string "Enter Title: " (zk--file-title buffer-file-name))))
+  (save-excursion
+    (goto-char (point-min))
+    (zk-new-note-header title id)))
+
+;;;###autoload
+(defun zk-insert-header-and-rename (id title)
+  "Same as `zk-insert-header' but also renames the note
+afterwards."
+  (interactive
+   (list
+    (read-string "Enter ID: " (zk--file-id buffer-file-name))
+    (read-string "Enter Title: " (zk--file-title buffer-file-name))))
+  (zk-insert-header id title)
+  (zk-rename-note))
 
 ;;;###autoload
 (defun zk-rename-note ()


### PR DESCRIPTION
I have migrated a lot of notes to zk and added a little helper command to insert zk headers manually to a pre-zk note. I thought maybe you would be interested to add this helper. 