### PR TITLE
Add named accessor for matching filename parts (id and title)

### DIFF
--- a/zk-desktop.el
+++ b/zk-desktop.el
@@ -229,7 +229,7 @@ To quickly change this setting, call `zk-desktop-add-toggle'."
                               (replace-match ""))
                             (when (re-search-forward "]]" end t)
                               (replace-match "")))
-                          (match-string-no-properties 1)))
+                          (zk--match-string-id)))
                    (title (buffer-substring-no-properties beg (match-beginning 0)))
                    (new-title (when (member id ids)
                                 (concat zk-desktop-prefix
@@ -249,7 +249,7 @@ To quickly change this setting, call `zk-desktop-add-toggle'."
           (while (re-search-forward zk-id-regexp nil t)
             (let* ((beg (line-beginning-position))
                    (end (line-end-position))
-                   (id (match-string-no-properties 1)))
+                   (id (zk--match-string-id)))
               (if (member id ids)
                   (progn
                     (make-text-button beg end 'type 'zk-desktop)
@@ -258,7 +258,7 @@ To quickly change this setting, call `zk-desktop-add-toggle'."
                       ;; find zk-links and plain zk-ids
                       (if (re-search-forward (zk-link-regexp) (line-end-position) t)
                           (replace-match
-                           (propertize (match-string 0) 'invisible t) nil t)
+                           (propertize (zk--match-string-id) 'invisible t) nil t)
                         (progn
                           (re-search-forward id)
                           (replace-match

--- a/zk-link-hint.el
+++ b/zk-link-hint.el
@@ -85,7 +85,7 @@ Only search the range between just after the point and BOUND."
                 (buffer (current-buffer))
                 (new-buffer))
             (if (re-search-forward zk-id-regexp (line-end-position))
-                (zk-follow-link-at-point (match-string-no-properties 0))
+                (zk-follow-link-at-point (zk--match-string-id))
               (push-button))
             (setq new-buffer
                   (current-buffer))

--- a/zk-org-link.el
+++ b/zk-org-link.el
@@ -105,7 +105,7 @@ Takes WIN, OBJ, and POS arguments."
      "%s"
      (zk--parse-id
       'title
-      (match-string 0)))))
+      (zk--match-string-id)))))
 
 (provide 'zk-org-link)
 


### PR DESCRIPTION
This allows using human-readable references to the parts of the filename, and potentially makes it possible to more easily change where the ID and title parts occur in the name. Since `zk--match-string-id` and `zk--match-string-title` are defined inline (correctly this time), there is no impact on performance whatsoever. In effect, these functions become syntactic sugar to make code easier to read and change.

The changes are well-tested, since I've used this branch on my "live" system for a few months without any issues.