### PR TITLE
Restructure zk--parse-id to accept only a single as argument

### DIFF
--- a/zk-index.el
+++ b/zk-index.el
@@ -392,7 +392,7 @@ items listed first.")
                   (zk--grep-id-list string))))
          (ids (mapcar (lambda (x) (when (member x scope) x))
                       query))
-         (files (zk--parse-id 'file-path (remq nil ids))))
+         (files (mapcar (lambda (id) (zk--parse-id 'file-path id)) ids)))
     (add-to-history 'zk-search-history string)
     (when files
       (let ((mode-line (zk-index-query-mode-line command string)))
@@ -525,7 +525,7 @@ with query term STRING."
 (defun zk-index--current-file-list ()
   "Return list files in current index."
   (let* ((ids (zk-index--current-id-list (buffer-name)))
-         (files (zk--parse-id 'file-path ids)))
+         (files (mapcar (lambda (id) (zk--parse-id 'file-path id)) ids)))
     (when files
       files)))
 

--- a/zk.el
+++ b/zk.el
@@ -1021,7 +1021,7 @@ Select TAG, with completion, from list of all tags in zk notes."
   "Find unlinked notes."
   (interactive)
   (let* ((ids (zk--unlinked-notes-list))
-         (notes (zk--parse-id 'file-path ids)))
+         (notes (mapcar (lambda (id) (zk--parse-id 'file-path id)) ids)))
     (if notes
         (find-file (funcall zk-select-file-function "Unlinked notes: " notes))
       (user-error "No unlinked notes found"))))

--- a/zk.el
+++ b/zk.el
@@ -536,23 +536,20 @@ file extension."
 ;;; Formatting
 
 (defun zk--processor (arg)
-  "Return list of files.
-ARG can be zk-file or zk-id as string or list, single or multiple."
+  "Process ARG into a list of zk-files.
+ARG can be a string (zk-file or zk-id) or a list of such strings."
   (let* ((zk-alist (zk--alist))
-         (files (cond
-                 ((stringp arg)
-                  (if (zk-file-p arg)
-                      (list arg)
-                    (list (zk--parse-id 'file-path arg zk-alist))))
-                 ((zk--singleton-p arg)
-                  (if (zk-file-p (car arg))
-                      arg
-                    (list (zk--parse-id 'file-path (car arg) zk-alist))))
-                 (t
-                  (if (zk-file-p (car arg))
-                      arg
-                    (zk--parse-id 'file-path arg zk-alist))))))
-    files))
+         (process-single-arg
+          (lambda (single-arg)
+            (if (zk-file-p single-arg)
+                single-arg
+              (zk--parse-id 'file-path single-arg zk-alist)))))
+    (cond ((stringp arg)                ; Single zk-file or zk-id as string
+           (list (funcall process-single-arg arg)))
+          ((listp arg)                  ; List of zk-files or zk-ids
+           (mapcar process-single-arg arg))
+          (t
+           (signal 'wrong-type-argument (list 'list-or-string-p arg))))))
 
 (defun zk--formatter (arg format &optional no-proc)
   "Return formatted list from FILES, according to FORMAT.

--- a/zk.el
+++ b/zk.el
@@ -495,46 +495,19 @@ supplied. Can take a PROMPT argument."
          ,file)))
    (zk--directory-files t)))
 
-(defun zk--parse-id (target ids &optional zk-alist)
-  "Return TARGET, either `file-path or `title, from files with IDS.
-Takes a single ID, as a string, or a list of IDs. Takes an
-optional ZK-ALIST, for efficiency if `zk--parse-id' is called
-in an internal loop."
-  (cond
-   ((and (eq target 'file-path)
-         (stringp ids))
-    (car (zk--directory-files t ids)))
-   ((and (eq target 'file-path)
-         (zk--singleton-p ids))
-    (car (zk--directory-files t (car ids))))
-   (t
-    (let* ((zk-alist (or zk-alist
-                         (zk--alist)))
-           (zk-id-list (zk--id-list))
-           (return
-            (cond ((eq target 'file-path)
-                   (cond ((stringp ids)
-                          (if (member ids zk-id-list)
-                              (cddr (assoc ids zk-alist))
-                            (user-error "No file associated with %s" ids)))
-                         ((listp ids)
-                          (mapcar
-                           (lambda (x)
-                             (caddr (assoc x zk-alist)))
-                           ids))))
-                  ((eq target 'title)
-                   (cond ((stringp ids)
-                          (if (member ids zk-id-list)
-                              (cadr (assoc ids zk-alist))
-                            (user-error "No file associated with %s" ids)))
-                         ((listp ids)
-                          (mapcar
-                           (lambda (x)
-                             (cadr (assoc x zk-alist)))
-                           ids)))))))
-      (if (zk--singleton-p return)
-          (car return)
-        return)))))
+(defun zk--parse-id (target id &optional zk-alist)
+  "Return TARGET, either `file-path or `title, from file with ID.
+Takes a single ID, as a string. Takes an optional ZK-ALIST, for
+efficiency if `zk--parse-id' is called in an internal loop."
+  (let* ((zk-alist (or zk-alist (zk--alist)))
+         (zk-id-list (zk--id-list)))
+    (unless (member id zk-id-list)
+      (user-error "No file associated with %s" id))
+    (cond ((eq target 'file-path)
+           (caddr (assoc id zk-alist)))
+          ((eq target 'title)
+           (cadr (assoc id zk-alist)))
+          (t (error "Invalid target: %s" target)))))
 
 (defun zk--parse-file (target files)
   "Return TARGET, either `id or `title, from FILES.

--- a/zk.el
+++ b/zk.el
@@ -519,15 +519,16 @@ supplied. Can take a PROMPT argument."
 (defun zk--parse-id (target id &optional zk-alist)
   "Return TARGET, either `file-path or `title, from file with ID.
 Takes a single ID, as a string. Takes an optional ZK-ALIST, for
-efficiency if `zk--parse-id' is called in an internal loop."
-  (let* ((zk-alist (or zk-alist (zk--alist)))
-         (zk-id-list (zk--id-list nil zk-alist)))
-    (unless (member id zk-id-list)
-      (user-error "No file associated with %s" id))
+backward compatibility, but ignores it in favor of checking against
+the file system directly via `zk--id-file'."
+  (let ((file (zk--id-file id)))
     (cond ((eq target 'file-path)
-           (caddr (assoc id zk-alist)))
+           file)
           ((eq target 'title)
-           (cadr (assoc id zk-alist)))
+           (if (string-match (zk-file-name-regexp) (file-name-nondirectory file))
+               (match-string 2 (file-name-nondirectory file))
+             (error "Cannot figure out title for file with ID %s: %s"
+                    id (file-name-nondirectory file))))
           (t (error "Invalid target: %s" target)))))
 
 (defun zk--parse-file (target files)

--- a/zk.el
+++ b/zk.el
@@ -317,6 +317,27 @@ The value is based on `zk-link-format' and `zk-id-regexp'."
   (when (string-match (zk-file-name-regexp) file)
     (match-string-no-properties 1 file)))
 
+(defun zk--id-file (id)
+  "Return the full file path for the existing zk note with ID.
+Use wildcards to match files against the ID, signalling an error if
+there are multiple matches (so ID is not unique). If there are no
+matches, return nil."
+  (let* ((wild-base-name (format "%s*.%s" id zk-file-extension))
+         (matches (file-expand-wildcards
+                   (concat (file-name-as-directory zk-directory)
+                           (when (functionp zk-subdirectory-function)
+                             (file-name-as-directory
+                              (funcall zk-subdirectory-function id)))
+                           wild-base-name))))
+    (cond ((zk--singleton-p matches)
+           (expand-file-name (car matches)))
+          ((null matches)
+           nil)
+          (t
+           (error "There are multiple (%d) files with ID %s"
+                  (length matches)
+                  id)))))
+
 (defun zk-file-p (&optional file strict)
   "Return t if FILE is a zk-file.
 If FILE is not given, get it from variable `buffer-file-name'.

--- a/zk.el
+++ b/zk.el
@@ -500,7 +500,7 @@ supplied. Can take a PROMPT argument."
 Takes a single ID, as a string. Takes an optional ZK-ALIST, for
 efficiency if `zk--parse-id' is called in an internal loop."
   (let* ((zk-alist (or zk-alist (zk--alist)))
-         (zk-id-list (zk--id-list)))
+         (zk-id-list (zk--id-list nil zk-alist)))
     (unless (member id zk-id-list)
       (user-error "No file associated with %s" id))
     (cond ((eq target 'file-path)


### PR DESCRIPTION
This change simplifies the `zk--parse-id` function to only handle single IDs, rather than trying to handle both lists of IDs and a single ID. The rationale for this change is as follows:

1) Simplification: Accepting a single ID as an argument reduces complexity and makes the function easier to understand.

2) Improved Error Handling: Error checking can be more explicit and localized within the function.

3) Consistency: A function should ideally have a single, consistent behavior. Having `zk--parse-id` always expect a single ID rather than variably accepting both a list and a single ID brings greater consistency to the codebase.

Aside from the changes already made, nothing else is affected. I will submit a pull request for making the change in `zk-luhmann`. 