### PR TITLE
Fix references to wrong match group in zk-id-regexp

### DIFF
--- a/zk-desktop.el
+++ b/zk-desktop.el
@@ -245,7 +245,7 @@ To quickly change this setting, call `zk-desktop-add-toggle'."
                               (replace-match ""))
                             (when (re-search-forward "]]" end t)
                               (replace-match "")))
-                          (match-string-no-properties 1)))
+                          (match-string-no-properties 0)))
                    (title (buffer-substring-no-properties beg (match-beginning 0)))
                    (new-title (when (member id ids)
                                 (concat zk-desktop-prefix
@@ -265,7 +265,7 @@ To quickly change this setting, call `zk-desktop-add-toggle'."
           (while (re-search-forward zk-id-regexp nil t)
             (let* ((beg (line-beginning-position))
                    (end (line-end-position))
-                   (id (match-string-no-properties 1)))
+                   (id (match-string-no-properties 0)))
               (if (member id ids)
                   (progn
                     (make-text-button beg end

--- a/zk-index.el
+++ b/zk-index.el
@@ -596,8 +596,7 @@ with query term STRING."
 (defun zk-index--button-at-point-p (&optional pos)
   "Return zk-id when `zk-index' button is at point.
 Takes an option POS position argument."
-  (let ((button (or pos
-                    (button-at (point)))))
+  (let ((button (button-at (or pos (point)))))
     (when (and button
                (button-has-type-p button 'zk-index))
       (save-excursion

--- a/zk-index.el
+++ b/zk-index.el
@@ -158,7 +158,7 @@ example."
     (save-excursion
       (beginning-of-line)
       (re-search-forward zk-id-regexp (line-end-position)))
-    (let ((zk-id (match-string-no-properties 1)))
+    (let ((zk-id (match-string-no-properties 0)))
       `(zk-id ,zk-id . ,(cons (line-beginning-position) (line-end-position))))))
 
 (defun zk-index-narrow (arg)
@@ -600,8 +600,8 @@ Takes an option POS position argument."
     (when (and button
                (button-has-type-p button 'zk-index))
       (save-excursion
-        (re-search-forward zk-id-regexp)
-        (match-string-no-properties 1)))))
+        (when (re-search-forward zk-id-regexp)
+          (match-string-no-properties 0))))))
 
 (defun zk-index-insert-link (&optional id)
   "Insert zk-link in `other-window' for button ID at point."

--- a/zk.el
+++ b/zk.el
@@ -123,10 +123,14 @@ If you change this value, set `zk-id-regexp' so that
 the zk IDs can be found."
   :type 'string)
 
-(defcustom zk-id-regexp "\\([0-9]\\{12\\}\\)"
+(defcustom zk-id-regexp "[0-9]\\{12\\}"
   "The regular expression used to search for zk IDs.
 Set it so that it matches strings generated with
-`zk-id-format'."
+`zk-id-format'. The expression should not capture any
+explicitly numbered groups.
+
+See `zk-file-name-regexp' and `zk-link-regexp' functions for
+how this regexp is used."
   :type 'regexp)
 
 (defcustom zk-tag-regexp "\\s#[a-zA-Z0-9]\\+"

--- a/zk.el
+++ b/zk.el
@@ -1010,8 +1010,8 @@ Select TAG, with completion, from list of all tags in zk notes."
          (list (split-string files "\n" t))
          (ids (mapcar
                (lambda (x)
-                 (string-match zk-id-regexp x)
-                 (match-string 0 x))
+                 (when (string-match zk-id-regexp x)
+                   (match-string 0 x)))
                list)))
     (delete-dups ids)))
 


### PR DESCRIPTION
I ran into this accidentally when testing some different values for `zk-id-regexp`, which made zk-index completely inoperable, since button actions were not finding the note ID.

The docstring does not specify that the regexp should be wrapped in `\\(...\\)`, but some code that matches against the regexp refers to match-string 1 while other instances (e.g. `zk--id-at-point`) reference the entire match (i.e. match-string 0). Since `zk-link-regexp` and `zk-file-name-regexp` add their own explicitly-numbered capture groups, it's best to consistently refer to the entire match when matching against `zk-id-regexp`.