### PR TITLE
Feature: consistent zk-link-format and POSIX regexp conversion for grep

### DIFF
--- a/zk-org-link.el
+++ b/zk-org-link.el
@@ -51,7 +51,7 @@
                          :help-echo #'zk-org-link--help-echo)
 
 ;; Set up org-style link format by setting variables
-(setq zk-link-format "[[zk:%s]]")
+(setq zk-link-format "[[zk:%i]]")
 (setq zk-link-and-title-format "[[zk:%i][%t]]")
 (setq zk-enable-link-buttons nil)
 

--- a/zk.el
+++ b/zk.el
@@ -312,13 +312,14 @@ Group 2 is the title."
           zk-file-extension
           ".*"))
 
-(defun zk-link-regexp ()
+(defun zk-link-regexp (&optional id title)
   "Return the correct regexp matching zk links.
-The value is based on `zk-link-format', `zk-id-regexp', and
-`zk-title-regexp'."
+If ID and/or TITLE are given, use those, generating a regexp that
+specifically matches them. Othewrise use `zk-id-regexp' and
+`zk-title-regexp', respectively."
   (zk--format (regexp-quote zk-link-format)
-              zk-id-regexp
-              zk-title-regexp))
+              (or id zk-id-regexp)
+              (or title zk-title-regexp)))
 
 (defun zk--file-id (file)
   "Return the ID of the given zk FILE."
@@ -956,7 +957,7 @@ brackets \"[[\" initiates completion."
 
 (defun zk--backlinks-list (id)
   "Return list of notes that link to note with ID."
-  (zk--grep-file-list (regexp-quote (format zk-link-format id))))
+  (zk--grep-file-list (zk-link-regexp id)))
 
 ;;;###autoload
 (defun zk-backlinks ()

--- a/zk.el
+++ b/zk.el
@@ -186,10 +186,11 @@ See `zk-format-id-and-title' for an example."
 
 ;; Format variables
 
-(defcustom zk-link-format "[[%s]]"
+(defcustom zk-link-format "[[%i]]"
   "Format for inserted links.
-Used in conjunction with `format', the string `%s' will be
-replaced by a note's ID."
+
+See `zk-format-id-and-title' for what the default control
+sequences mean."
   :type 'string)
 
 (defcustom zk-link-and-title-format "%t [[%i]]"
@@ -623,11 +624,9 @@ that `zk-format-function' is set to."
   (format-spec format `((?i . ,id) (?t . ,title))))
 
 (defun zk--format (format id title)
-  "Format ID and TITLE based on the `format-spec' FORMAT."
-  (if (eq format zk-link-format)
-      (format zk-link-format id)
-    (funcall zk-format-function format id title)))
-
+  "Format ID and TITLE based on the `format-spec' FORMAT.
+This is a wrapper around `zk-format-function', which see."
+  (funcall zk-format-function format id title))
 
 ;;; Buttons
 

--- a/zk.el
+++ b/zk.el
@@ -175,8 +175,8 @@ See `zk-current-notes' for details."
 
 (defcustom zk-format-function #'zk-format-id-and-title
   "Function for formatting zk file information.
-It should accept three variables: FORMAT-SPEC, ID, and TITLE. See
-`zk--format' for details."
+It should accept three variables: FORMAT-SPEC, ID, and TITLE.
+See `zk-format-id-and-title' for an example."
   :type 'function)
 
 ;; Format variables
@@ -190,15 +190,15 @@ replaced by a note's ID."
 (defcustom zk-link-and-title-format "%t [[%i]]"
   "Format for link and title when inserted to together.
 
-By default (when `zk-format-function' is nil), the string `%t' will be
-replaced by the note's title and `%i' will be replaced by its ID."
+See `zk-format-id-and-title' for what the default control
+sequences mean."
   :type 'string)
 
 (defcustom zk-completion-at-point-format "[[%i]] %t"
   "Format for completion table used by `zk-completion-at-point'.
 
-By default (when `zk-format-function' is nil), the string `%t' will be
-replaced by the note's title and `%i' will be replaced by its ID."
+See `zk-format-id-and-title' for what the default control
+sequences mean."
   :type 'string)
 
 ;; Link variables
@@ -604,9 +604,9 @@ When NO-PROC is non-nil, bypass `zk--processor'."
 
 (defun zk-format-id-and-title (format id title)
   "Format ID and TITLE based on the `format-spec' FORMAT.
-This is the default function set in `zk-format-function' and used by
-`zk--format' therwise, replace the sequence `%t' with the TITLE and
-`%i' with the ID."
+The sequence `%t' in FORMAT is replaced with the TITLE
+and `%i' with the ID. This is the default function
+that `zk-format-function' is set to."
   (format-spec format `((?i . ,id) (?t . ,title))))
 
 (defun zk--format (format id title)

--- a/zk.el
+++ b/zk.el
@@ -314,12 +314,16 @@ Group 2 is the title."
 
 (defun zk-link-regexp (&optional id title)
   "Return the correct regexp matching zk links.
-If ID and/or TITLE are given, use those, generating a regexp that
-specifically matches them. Othewrise use `zk-id-regexp' and
-`zk-title-regexp', respectively."
+If ID and/or TITLE are given, use those, generating a regexp
+that specifically matches them. Othewrise use `zk-id-regexp'
+and `zk-title-regexp', respectively.
+The regexp captures these groups:
+
+Group 1 is the zk ID.
+Group 2 is the title."
   (zk--format (regexp-quote zk-link-format)
-              (or id zk-id-regexp)
-              (or title zk-title-regexp)))
+              (concat "\\(?1:" (or id zk-id-regexp) "\\)")
+              (concat "\\(?2:" (or title zk-title-regexp) "\\)")))
 
 (defun zk--file-id (file)
   "Return the ID of the given zk FILE."

--- a/zk.el
+++ b/zk.el
@@ -117,16 +117,21 @@ rendered with spaces."
 
 (defcustom zk-id-time-string-format "%Y%m%d%H%M"
   "Format for new zk IDs.
-For supported options, please consult `format-time-string'.
-Note: the regexp to find zk IDs is set separately.
-If you change this value, set `zk-id-regexp' so that
-the zk IDs can be found."
+For supported options,  consult `format-time-string'.
+
+Note: The regexp to find zk IDs is set separately. If you change
+this value, set `zk-id-regexp' so that the zk IDs can be found."
   :type 'string)
 
 (defcustom zk-id-regexp "\\([0-9]\\{12\\}\\)"
   "The regular expression used to search for zk IDs.
 Set it so that it matches strings generated with
-`zk-id-format'."
+`zk-id-time-string-format'."
+  :type 'regexp)
+
+(defcustom zk-title-regexp ".*?"
+  "The regular expression used to match the zk note's title.
+This is only relevant if `zk-link-format' includes the title."
   :type 'regexp)
 
 (defcustom zk-tag-regexp "\\s#[a-zA-Z0-9]\\+"
@@ -154,7 +159,7 @@ Must take a single STRING argument."
   :type 'function)
 
 (make-obsolete-variable 'zk-grep-function "The use of the
-  'zk-grep-function' variable is deprecated.
+ 'zk-grep-function' variable is deprecated.
  'zk-search-function' should be used instead"
                         "0.5")
 
@@ -302,15 +307,18 @@ Group 1 is the zk ID.
 Group 2 is the title."
   (concat "\\(?1:" zk-id-regexp "\\)"
           "."
-          "\\(?2:.*?\\)"
+          "\\(?2:" zk-title-regexp "\\)"
           "\\."
           zk-file-extension
           ".*"))
 
 (defun zk-link-regexp ()
-  "Return the correct regexp for zk links.
-The value is based on `zk-link-format' and `zk-id-regexp'."
-  (format (regexp-quote zk-link-format) zk-id-regexp))
+  "Return the correct regexp matching zk links.
+The value is based on `zk-link-format', `zk-id-regexp', and
+`zk-title-regexp'."
+  (zk--format (regexp-quote zk-link-format)
+              zk-id-regexp
+              zk-title-regexp))
 
 (defun zk--file-id (file)
   "Return the ID of the given zk FILE."


### PR DESCRIPTION
This is a new version of PR #63 that fixes the `zk-backlinks` bug.

### Consistent zk-link-format

This changes `zk-link-format` to use same %-sequences as other `zk-*-format` variables.
Having consistent syntax is helpful to avoid mistakes. Additionally, this change allows 1) simplifying `zk--format` so it doesn't need to handle two different sets of %-sequences, and 2) experimenting with other link markup, such as `[[%i][%t]]` for org-mode links without explicit link type or `[[%i|%t]]` for syntax used by MediaWiki.

### Extend zk-link-regexp to generate targeted regexps

Also, `zk-link-regexp` function now accepts optional ID and/or title to generate a regexp matching specific links, so that with the default `zk-link-format`, `(zk-link-regexp "202307090142")` returns `"\\[\\[\\(?1:202307090142\\)]]"`. The explicitly numbered capture groups are consistent with `zk-file-name-regexp`.

### Introduce zk--posix-regexp

So far, functions like `zk--grep-file-list` have just passed Elisp-style regexp to `grep` and hoped it works, which it does for zk-ID or other literal strings. Changes to `zk-link-regexp` in PR #63 broke things because it introduced explicit capture groups (`\(?1:...\)`), which is not supported by POSIX regexps that `grep` uses.

The new function, `zk--posix-regexp`, does some basic conversion from Elisp-style regexps to POSIX-style. There is package `pcre2el` that does it in a more complete and sophisticated way, but for our purposes, this should be enough.

Functions that pass regexps to `grep`, such as `zk--grep-file-list`, `zk--grep-tag-list`, and `zk--grep-link-id-list` are updated to sanitize ("POSIXize") the regexps they pass. The cost is minuscule ("Elapsed time: 0.000379s" for 10,000 calls with a complex regexp).