### PR TITLE
Extend zk--id-list to query IDs as well as titles

### DIFF
--- a/zk.el
+++ b/zk.el
@@ -344,16 +344,17 @@ The ID is created using `zk-id-time-string-format'."
 
 (defun zk--id-list (&optional str zk-alist)
   "Return a list of zk IDs for notes in `zk-directory'.
-Optional search for STR in note title, case-insenstive. Takes an
-optional ZK-ALIST, for efficiency if `zk--id-list' is called in
-an internal loop."
+Optional search for STR in note ID and title,
+case-insenstive. Takes an optional ZK-ALIST, for efficiency
+if `zk--id-list' is called in an internal loop."
   (if str
       (let ((zk-alist (or zk-alist (zk--alist)))
             (case-fold-search t)
             (ids))
         (dolist (item zk-alist)
           (if str
-              (when (string-match str (cadr item))
+              (when (or (string-match str (car item))
+                        (string-match str (cadr item)))
                 (push (car item) ids))
             (push (car item) ids)))
         ids)


### PR DESCRIPTION
This is a very minor change that does not effect performance, but allows focusing on parts of IDs as well as titles. So I can focus on only the notes I made in 2014, for example, by querying for `^2014`, or notes I've made in July of any year with `^20..07`.

Benchmarks:
```
=== bm/zk--id-list+search-ids (10 reps) at 2023-07-16 14:57 ===
((zk--id-list))                          =>  3049 results in 1.01 sec (inc. 0.62 sec for 1 GCs)
((zk--id-list/rb))                       =>  3049 results in 1.00 sec (inc. 0.61 sec for 1 GCs)
((zk--id-list "yomi"))                   =>    41 results in 2.45 sec (inc. 1.75 sec for 2 GCs)
((zk--id-list/rb "yomi"))                =>    41 results in 2.46 sec (inc. 1.75 sec for 2 GCs)
((zk--id-list "^2014"))                  =>     0 results in 2.44 sec (inc. 1.74 sec for 2 GCs)
((zk--id-list/rb "^2014"))               =>   281 results in 2.44 sec (inc. 1.74 sec for 2 GCs)
((zk--id-list nil zk-alist))             =>  3049 results in 1.04 sec (inc. 0.65 sec for 1 GCs)
((zk--id-list/rb nil zk-alist))          =>  3049 results in 1.02 sec (inc. 0.63 sec for 1 GCs)
((zk--id-list "yomi" zk-alist))          =>    41 results in 0.04 sec (inc. 0.02 sec for 0 GCs)
((zk--id-list/rb "yomi" zk-alist))       =>    41 results in 0.05 sec (inc. 0.02 sec for 0 GCs)
```